### PR TITLE
✨ Feat:공통 Chip UI 수정

### DIFF
--- a/src/shared/components/chip/BgrChip.stories.tsx
+++ b/src/shared/components/chip/BgrChip.stories.tsx
@@ -76,6 +76,9 @@ export const AllVariants: Story = {
                 <BgrChip selected>Active</BgrChip>
             </div>
             <div className="flex gap-2 items-center flex-wrap">
+                <BgrChip selected={false} size='sm' closable onClose={fn()}>
+                    Closable
+                </BgrChip>
                 <BgrChip selected={false} closable onClose={fn()}>
                     Closable
                 </BgrChip>

--- a/src/shared/components/chip/BgrChip.stories.tsx
+++ b/src/shared/components/chip/BgrChip.stories.tsx
@@ -10,9 +10,8 @@ const meta = {
     },
     tags: ['autodocs'],
     argTypes: {
-        variant: {
-            control: 'select',
-            options: ['default', 'primary', 'secondary'],
+        selected: {
+            control: 'boolean'
         },
         size: {
             control: 'select',
@@ -33,34 +32,24 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
     args: {
         children: 'Chip',
-        variant: 'default',
         size: 'md',
         closable: false,
+        selected: false,
     },
 }
 
-export const Primary: Story = {
+export const Selected: Story = {
     args: {
-        children: 'Primary Chip',
-        variant: 'primary',
+        children: 'Selected Chip',
         size: 'md',
-        closable: false,
-    },
+        selected: true
+    }
 }
 
-export const Secondary: Story = {
-    args: {
-        children: 'Secondary Chip',
-        variant: 'secondary',
-        size: 'md',
-        closable: false,
-    },
-}
 
 export const Closable: Story = {
     args: {
         children: 'Closable Chip',
-        variant: 'default',
         size: 'md',
         closable: true,
         onClose: fn(),
@@ -70,7 +59,6 @@ export const Closable: Story = {
 export const Small: Story = {
     args: {
         children: 'Small Chip',
-        variant: 'default',
         size: 'sm',
         closable: false,
     },
@@ -83,15 +71,15 @@ export const AllVariants: Story = {
     render: () => (
         <div className="flex flex-col gap-4">
             <div className="flex gap-2 items-center flex-wrap">
-                <BgrChip variant="default">Default</BgrChip>
-                <BgrChip variant="primary">Primary</BgrChip>
-                <BgrChip variant="secondary">Secondary</BgrChip>
+                <BgrChip selected={false} size='sm'>Small</BgrChip>
+                <BgrChip selected={false}>Default</BgrChip>
+                <BgrChip selected>Active</BgrChip>
             </div>
             <div className="flex gap-2 items-center flex-wrap">
-                <BgrChip variant="default" closable onClose={fn()}>
+                <BgrChip selected={false} closable onClose={fn()}>
                     Closable
                 </BgrChip>
-                <BgrChip variant="primary" closable onClose={fn()}>
+                <BgrChip selected closable onClose={fn()}>
                     Closable Primary
                 </BgrChip>
             </div>

--- a/src/shared/components/chip/BgrChip.tsx
+++ b/src/shared/components/chip/BgrChip.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { cn } from 'src/shared/lib/shadcn/lib/utils'
 import { X } from 'lucide-react'
 
 interface BgrChipProps {
@@ -29,16 +30,21 @@ const BgrChip = ({
     }
 
     const sizeClasses = {
-        sm: 'px-2 py-1 text-[10px] rounded-full',
-        md: 'px-3 py-1.5 text-[12px] rounded-full',
+        sm: 'px-2 py-1 text-body-10-r rounded-full',
+        md: 'px-3 py-1.5 text-body-12-r rounded-full',
+    }
+
+    const closeClasses = {
+        sm: 'w-3 h-3',
+        md: 'w-4 h-4'
     }
 
     return (
         <span
             className={clsx(
                 'inline-flex items-center justify-center gap-1 border border-solid transition-colors duration-150',
-                selected ? variantClasses.selected.default : variantClasses.base.default,
                 sizeClasses[size],
+                selected ? variantClasses.selected.default : variantClasses.base.default,
                 className,
             )}
         >
@@ -50,7 +56,9 @@ const BgrChip = ({
                     className="flex items-center justify-center hover:opacity-70 transition-opacity"
                     aria-label="닫기"
                 >
-                    <X className="w-4 h-4" />
+                    <X className={cn(
+                        closeClasses[size]
+                    )} />
                 </button>
             )}
         </span>

--- a/src/shared/components/chip/BgrChip.tsx
+++ b/src/shared/components/chip/BgrChip.tsx
@@ -3,40 +3,41 @@ import { X } from 'lucide-react'
 
 interface BgrChipProps {
     children: React.ReactNode
-    variant?: 'default' | 'primary' | 'secondary'
     size?: 'sm' | 'md'
     closable?: boolean
+    selected?: boolean
     onClose?: () => void
     className?: string
 }
 
 const BgrChip = ({
     children,
-    variant = 'default',
     size = 'md',
     closable = false,
+    selected = false,
     onClose,
     className = '',
 }: BgrChipProps) => {
+
     const variantClasses = {
-        default:
-            'bg-white border-gray-200 text-gray-800 border border-solid',
-        primary:
-            'bg-white border-primary-500 text-primary-500 border border-solid',
-        secondary:
-            'bg-gray-50 border-gray-300 text-gray-800 border border-solid',
+        base : {
+            default : 'bg-white border-gray-200 text-gray-800 font-normal hover:bg-gray-50 active:bg-gray-200',
+        },
+        selected : {
+            default : 'bg-white border-primary-500 text-primary-500 font-semibold hover:bg-gray-50 active:bg-gray-200',
+        }
     }
 
     const sizeClasses = {
-        sm: 'px-3 py-1.5 text-body-12-sb rounded-full',
-        md: 'px-3 py-1.5 text-body-12-sb rounded-full',
+        sm: 'px-2 py-1 text-[10px] rounded-full',
+        md: 'px-3 py-1.5 text-[12px] rounded-full',
     }
 
     return (
         <span
             className={clsx(
-                'inline-flex items-center justify-center gap-2',
-                variantClasses[variant],
+                'inline-flex items-center justify-center gap-1 border border-solid transition-colors duration-150',
+                selected ? variantClasses.selected.default : variantClasses.base.default,
                 sizeClasses[size],
                 className,
             )}
@@ -49,7 +50,7 @@ const BgrChip = ({
                     className="flex items-center justify-center hover:opacity-70 transition-opacity"
                     aria-label="닫기"
                 >
-                    <X className="w-3 h-3" />
+                    <X className="w-4 h-4" />
                 </button>
             )}
         </span>


### PR DESCRIPTION
## 이슈 번호
없습니다

## 작업 내용 및 테스트 방법
피그마 내용을 바탕으로 기존 Chip UI 구조를 수정했습니다.

**변경 내용**
- variant 제거
- effect 추가 (hover, press)
- active 상태는 selected props를 추가해 구현
- 기존 sizeClasses의 sm, md 내용이 동일한 이슈 있었음 -> 피그마 디자인 참고해 올바르게 반영

**기타**
- 스토리북 BgrChip 폴더에 반영되었습니다,
<img width="283" height="153" alt="image" src="https://github.com/user-attachments/assets/12c1dd43-fe98-4d8f-85e5-4ecd50d7ceb3" />


## To reviewers

피그마 디자인 시스템 Chip 을 보고 반영했습니다!
active 디자인의 경우 별도의 hover, press 없어서 임시로 default 상태와 동일하게 처리 한 상태입니다.

