### PR TITLE
✨ Feat: 공통 Popover 컴포넌트 추가 및 Button 컴포넌트 개선

### DIFF
--- a/src/shared/components/ui/button/button.tsx
+++ b/src/shared/components/ui/button/button.tsx
@@ -1,9 +1,8 @@
+import * as React from 'react'
 import { cn } from '@/shared/lib/utils'
 
-interface ButtonProps {
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   title: string
-  onClick?: () => void
-  disabled?: boolean
   variant?:
     | 'primary-filled'
     | 'primary-outlined'
@@ -13,60 +12,69 @@ interface ButtonProps {
   roundedFull?: boolean
   leftIcon?: React.ReactNode
   rightIcon?: React.ReactNode
-  className?: string
 }
 
-const Button = ({
-  title,
-  onClick,
-  disabled = false,
-  variant = 'primary-filled',
-  size = 'md',
-  roundedFull = false,
-  leftIcon,
-  rightIcon,
-  className = '',
-}: ButtonProps) => {
-  const sizeClasses = {
-    sm: 'h-button-sm min-w-[56px] px-10 py-8 rounded-8',
-    md: 'h-button-md min-w-[90px] px-16 py-12 rounded-10',
-    lg: 'h-button-lg min-w-[180px] px-16 py-16 rounded-12',
-  }
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      title,
+      onClick,
+      disabled = false,
+      variant = 'primary-filled',
+      size = 'md',
+      roundedFull = false,
+      leftIcon,
+      rightIcon,
+      className = '',
+      ...props
+    },
+    ref,
+  ) => {
+    const sizeClasses = {
+      sm: 'h-button-sm min-w-[56px] px-10 py-8 rounded-8',
+      md: 'h-button-md min-w-[90px] px-16 py-12 rounded-10',
+      lg: 'h-button-lg min-w-[180px] px-16 py-16 rounded-12',
+    }
 
-  const typoClasses = {
-    sm: 'typo-body-12-m',
-    md: 'typo-title-16-m',
-    lg: 'typo-heading-18-m',
-  }
+    const typoClasses = {
+      sm: 'typo-body-12-m',
+      md: 'typo-title-16-m',
+      lg: 'typo-heading-18-m',
+    }
 
-  const variantClasses = {
-    'primary-filled':
-      'bg-primary-500 border-primary-500 text-white hover:bg-primary-600 hover:border-primary-600 active:bg-primary-700 active:border-primary-700 focus-visible:bg-primary-700 focus-visible:border-primary-700',
-    'primary-outlined':
-      'bg-white border-primary-500 text-primary-500 hover:bg-primary-50 hover:border-primary-600 active:bg-primary-100 active:border-primary-700 focus-visible:bg-primary-50 focus-visible:border-primary-700',
-    'secondary-filled':
-      'bg-gray-900 border-gray-900 text-white hover:bg-gray-800 hover:border-gray-800 active:bg-gray-700 active:border-gray-700 focus-visible:bg-gray-700 focus-visible:border-gray-700',
-    'secondary-outlined':
-      'bg-white border-gray-200 text-gray-900 hover:bg-gray-50 hover:border-gray-50 active:bg-gray-100 active:border-gray-200 focus-visible:bg-gray-50 focus-visible:border-gray-200',
-  }
+    const variantClasses = {
+      'primary-filled':
+        'bg-primary-500 border-primary-500 text-white hover:bg-primary-600 hover:border-primary-600 active:bg-primary-700 active:border-primary-700 focus-visible:bg-primary-700 focus-visible:border-primary-700',
+      'primary-outlined':
+        'bg-white border-primary-500 text-primary-500 hover:bg-primary-50 hover:border-primary-600 active:bg-primary-100 active:border-primary-700 focus-visible:bg-primary-50 focus-visible:border-primary-700',
+      'secondary-filled':
+        'bg-gray-900 border-gray-900 text-white hover:bg-gray-800 hover:border-gray-800 active:bg-gray-700 active:border-gray-700 focus-visible:bg-gray-700 focus-visible:border-gray-700',
+      'secondary-outlined':
+        'bg-white border-gray-200 text-gray-900 hover:bg-gray-50 hover:border-gray-50 active:bg-gray-100 active:border-gray-200 focus-visible:bg-gray-50 focus-visible:border-gray-200',
+    }
 
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        'flex items-center justify-center gap-8 border disabled:opacity-50',
-        sizeClasses[size],
-        variantClasses[variant],
-        roundedFull && 'rounded-full',
-        className,
-      )}
-    >
-      {leftIcon && leftIcon}
-      <span className={typoClasses[size]}>{title}</span>
-      {rightIcon && rightIcon}
-    </button>
-  )
-}
+    return (
+      <button
+        ref={ref}
+        onClick={onClick}
+        disabled={disabled}
+        className={cn(
+          'flex cursor-pointer items-center justify-center gap-8 border disabled:opacity-50',
+          sizeClasses[size],
+          variantClasses[variant],
+          roundedFull && 'rounded-full',
+          className,
+        )}
+        {...props}
+      >
+        {leftIcon && leftIcon}
+        <span className={typoClasses[size]}>{title}</span>
+        {rightIcon && rightIcon}
+      </button>
+    )
+  },
+)
+
+Button.displayName = 'Button'
 
 export default Button

--- a/src/shared/components/ui/popover/popover.stories.tsx
+++ b/src/shared/components/ui/popover/popover.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Popover, PopoverContent, PopoverTrigger } from './popover'
+import Button from '../button/button'
+
+const meta = {
+  title: 'Components/Popover',
+  component: PopoverContent,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: '팝오버의 제목',
+    },
+    showClose: {
+      control: 'boolean',
+      description: '닫기 버튼 표시 여부',
+    },
+    align: {
+      control: 'select',
+      options: ['start', 'center', 'end'],
+      description: '팝오버의 정렬 방식',
+    },
+    side: {
+      control: 'select',
+      options: ['top', 'right', 'bottom', 'left'],
+      description: '팝오버가 나타날 방향',
+    },
+    sideOffset: {
+      control: 'number',
+      description: '트리거와의 거리 (px)',
+    },
+  },
+} satisfies Meta<typeof PopoverContent>
+
+export default meta
+type Story = StoryObj<typeof PopoverContent>
+
+export const Default: Story = {
+  args: {
+    title: 'Main Title',
+    showClose: true,
+    align: 'center',
+    side: 'bottom',
+    sideOffset: 4,
+  },
+  render: (args) => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button title="Click Me" variant="primary-filled" />
+      </PopoverTrigger>
+      <PopoverContent {...args}>
+        <div className="flex flex-col gap-4">
+          <p className="typo-body-12-r text-gray-700">
+            This is a basic popover content.
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+}

--- a/src/shared/components/ui/popover/popover.tsx
+++ b/src/shared/components/ui/popover/popover.tsx
@@ -1,0 +1,66 @@
+import * as PopoverPrimitive from '@radix-ui/react-popover'
+import * as React from 'react'
+import { cn } from '@/shared/lib/utils'
+import { X } from 'lucide-react'
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverAnchor = PopoverPrimitive.Anchor
+
+const PopoverContent = React.forwardRef<
+  React.ComponentRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+    title?: string
+    showClose?: boolean
+  }
+>(
+  (
+    {
+      className,
+      align = 'center',
+      sideOffset = 4,
+      title,
+      showClose = true,
+      children,
+      ...props
+    },
+    ref,
+  ) => (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-auto max-w-[900px] min-w-[326px] rounded-16 border border-gray-200 bg-white shadow-md outline-none',
+          className,
+        )}
+        {...props}
+      >
+        <div className="flex flex-col">
+          {(title || showClose) && (
+            <div className="flex items-center justify-between px-20 py-10">
+              {title && (
+                <h3 className="typo-heading-24-m text-nowrap text-gray-800">
+                  {title}
+                </h3>
+              )}
+              {showClose && (
+                <PopoverPrimitive.Close className="rounded-sm border-none opacity-70 transition-opacity hover:opacity-100 focus:outline-none disabled:pointer-events-none">
+                  <X className="size-30 text-gray-800" />
+                  <span className="sr-only">Close</span>
+                </PopoverPrimitive.Close>
+              )}
+            </div>
+          )}
+          <div className="px-20 pb-20">{children}</div>
+        </div>
+      </PopoverPrimitive.Content>
+    </PopoverPrimitive.Portal>
+  ),
+)
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }


### PR DESCRIPTION
<img width="467" height="265" alt="image" src="https://github.com/user-attachments/assets/ddb3440d-166b-4733-8dba-f75c35dd4c4a" />

## 🚀 작업 내용
- **공통 Popover 컴포넌트 신규 구현**
  - `Radix UI Popover`를 기반으로 프로젝트 디자인 시스템에 맞춘 공통 컴포넌트 추가
  - 타이틀 및 닫기 버튼 레이아웃 포함
  - 디자인 가이드 반영: 너비 제약(326px ~ 900px), 둥근 모서리(16px), 그림자 효과 등
- **Button 컴포넌트 호환성 개선**
  - `forwardRef` 적용으로 Popover/Tooltip 등 headless UI 라이브러리와의 연동성 확보
  - `prop spreading` 지원을 통해 표준 HTML 버튼 속성 및 이벤트 핸들러 활용 가능하도록 개선