### PR TITLE
💄 Style: DatePicker label 스타일 및 z-index 조정

### DIFF
--- a/src/shared/components/blocks/date-picker/date-picker.tsx
+++ b/src/shared/components/blocks/date-picker/date-picker.tsx
@@ -63,8 +63,8 @@ export function DatePicker({
   }
 
   return (
-    <div className="flex w-full flex-col gap-24 bg-white">
-      <label className="typo-title-14-m text-gray-700">{label}</label>
+    <div className="flex w-full flex-col gap-6 bg-white">
+      <label className="typo-body-12-r text-gray-800">{label}</label>
 
       <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
         <Popover.Trigger asChild>
@@ -72,7 +72,7 @@ export function DatePicker({
             type="button"
             disabled={disabled}
             className={cn(
-              'flex items-center justify-between gap-24',
+              'flex items-center justify-between gap-6',
               'h-input px-12 py-8',
               'typo-title-16-r text-gray-800',
               'rounded-10 border border-gray-300',
@@ -86,7 +86,7 @@ export function DatePicker({
           </button>
         </Popover.Trigger>
 
-        <Popover.Content className="pt-4">
+        <Popover.Content className="z-dropdown pt-4">
           <Calendar
             selected={draftRange}
             onSelect={setDraftRange}


### PR DESCRIPTION
## 이슈 번호

Closes #67

## 작업 내용 및 테스트 방법

DatePicker 컴포넌트의 스타일을 디자인 시스템과 일관되게 조정했습니다.

- **Label 스타일 수정**: 타이포그래피 및 색상 개선
  - 타이포그래피: typo-title-14-m → typo-body-12-r (더 작은 크기)
  - 색상: text-gray-700 → text-gray-800 (더 진한 색)

- **간격 조정**: 컴팩트 레이아웃으로 개선
  - label과 입력창: gap-24 → gap-6
  - 아이콘과 텍스트: gap-24 → gap-6

- **레이어링 개선**: Popover z-index 추가
  - z-dropdown 추가로 다른 요소와의 겹침 처리

## To reviewers
- Popover z-index가 기존 dropdown 레이어링과 적절하게 작동하는지 검토 부탁합니다.