### PR TITLE
📦 Chore: @dessert/icons 패키지 eslint 설정 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -137,4 +137,17 @@ export default tseslint.config(
       },
     },
   },
+
+  // ── packages/icons 전용: tsconfig 경로 ──
+  {
+    files: ['packages/icons/**/*.{ts,tsx}'],
+    settings: {
+      'import/resolver': {
+        typescript: {
+          alwaysTryTypes: true,
+          project: './packages/icons/tsconfig.json',
+        },
+      },
+    },
+  },
 )

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -6,6 +6,9 @@
     ".": "./src/index.ts",
     "./styles": "./src/styles/index.css"
   },
+  "scripts": {
+    "lint": "eslint ."
+  },
   "peerDependencies": {
     "react": "^19.0.0"
   }


### PR DESCRIPTION
## 이슈 번호

Closes #90

## 작업 내용 및 테스트 방법

@dessert/icons 패키지에 독립적인 ESLint 설정을 추가하고 lint 명령어를 구성했습니다.

- **ESLint 설정 추가**: root eslint.config.js에 packages/icons 전용 설정
  - files 패턴으로 스코프 설정 (packages/icons/**/*.{ts,tsx})
  - TypeScript import resolver 경로 지정

- **lint 스크립트 추가**: packages/icons/package.json에 lint 명령어 추가
  - 패키지 독립적으로 lint 실행 가능

## To reviewers