### PR TITLE
🐛 Fix: CloudFront 캐시 무효화 명령어 경로 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,4 +93,4 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.SELLER_CLOUDFRONT_DISTRIBUTION_ID }} \
-            --paths "/index.html"
+            --paths "/*"


### PR DESCRIPTION
## 이슈 번호

Closes #98

## 작업 내용 및 테스트 방법

- CloudFront 캐시 무효화 경로 수정
  - `"/index.html"` → `"/*"` 변경
  - 배포 시 모든 파일에 대한 캐시 무효화 적용

## To reviewers