### PR TITLE
📦 Chore: CD 워크플로우 수동 배포 트리거 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,16 @@ name: CD
 on:
   push:
     branches: [develop]
+  workflow_dispatch:
+    inputs:
+      deploy_seller:
+        description: "Seller Service Manual Deploy"
+        type: boolean
+        default: false
+      deploy_admin:
+        description: "Admin Service Manual Deploy"
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -42,7 +52,7 @@ jobs:
   # ─────────────────────────────────────
   deploy-seller:
     needs: detect-changes
-    if: needs.detect-changes.outputs.seller == 'true'
+    if: needs.detect-changes.outputs.seller == 'true' || github.event.inputs.deploy_seller == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -94,3 +104,13 @@ jobs:
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.SELLER_CLOUDFRONT_DISTRIBUTION_ID }} \
             --paths "/*"
+
+  # ─────────────────────────────────────
+  # 3단계: Admin 앱 배포 (향후 구현)
+  # ─────────────────────────────────────
+  deploy-admin:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.admin == 'true' || github.event.inputs.deploy_admin == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "Admin 배포 미구현"


### PR DESCRIPTION
## 이슈 번호

Closes #99

## 작업 내용 및 테스트 방법

- workflow_dispatch 트리거 추가
  - GitHub Actions UI에서 수동으로 배포 시작 가능
  - deploy_seller, deploy_admin 선택 옵션 제공

- deploy-seller, deploy-admin 조건문에 수동 배포 입력값 추가

- deploy-admin 작업 스켈레톤 추가 (향후 구현)

## To reviewers

- GitHub Actions 워크플로우 탭에서 workflow_dispatch 옵션이 정상 표시되는지 확인해주세요.
- 선택한 옵션(deploy_seller, deploy_admin)에 따라 해당 서비스만 배포되는지 확인이 필요합니다.

## 참고사항

dorny/paths-filter는 seller/admin 코드 변경 시에만 배포를 트리거하기 때문에, 초기 배포 또는 인프라 변경 시 수동으로 강제 배포할 수 있도록 추가했습니다.