### PR TITLE
📦 Chore: Eslint ignores 설정 항목 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,20 @@ import betterTailwind from 'eslint-plugin-better-tailwindcss'
 import importPlugin from 'eslint-plugin-import'
 
 export default tseslint.config(
-  { ignores: ['**/dist', '.yarn/releases'] },
+  {
+    ignores: [
+      // 빌드 산출물
+      '**/dist',
+      '**/storybook-static',
+      // 테스트 커버리지 리포트
+      '**/coverage',
+      // Turbo 캐시
+      '**/.turbo',
+      // Yarn 내부 파일
+      '.yarn/releases',
+      '.yarn/cache',
+    ],
+  },
 
   // ── 공통 규칙: seller + admin + packages 모두 적용 ──
   {


### PR DESCRIPTION
## 이슈 번호

Closes #130

## 작업 내용 및 테스트 방법

- eslint.config.js ignores 항목 추가
  - storybook-static (Storybook 빌드 산출물)
  - coverage (테스트 커버리지 리포트)
  - .turbo (Turbo 캐시)
  - .yarn/cache (Yarn 캐시)

- 카테고리별 주석 추가로 각 항목의 용도 명확화

## To reviewers

- yarn lint 실행 시 storybook-static 관련 "Definition for rule 'regexp/...' was not found" 에러가 해결되었는지 확인해주세요.
- 빌드 및 테스트 관련 디렉토리가 제외되어 lint 성능이 개선되었는지 확인해주세요.