### PR TITLE
📦 Chore: CodeRabbit 코드 리뷰 브랜치 범위 확장

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -76,6 +76,10 @@ reviews:
   auto_review:
     enabled: true # 자동 리뷰 켬
     drafts: false # Draft PR은 자동 리뷰 안 함
+    # 리뷰 대상 base 브랜치 패턴 (develop + feat/* 간 PR도 리뷰)
+    base_branches:
+      - develop
+      - 'feat/.*'
 
   # 에이전트용 프롬프트를 추가로 출력/활용할지 여부
   enable_prompt_for_ai_agents: false


### PR DESCRIPTION
## 이슈 번호

Closes #134

## 작업 내용 및 테스트 방법

- CodeRabbit 설정 파일 (coderabbit.yaml) 수정
  - auto_review base_branches에 `feat/.*` 패턴 추가
  - develop 및 feature 브랜치로의 PR 모두 자동 리뷰 적용

## To reviewers

- feat 브랜치로의 PR 생성 시 CodeRabbit이 정상적으로 자동 리뷰를 시작하는지 확인해주세요.
- 브랜치 체이닝 구조(feat/parent → feat/child)에서도 자동 리뷰가 작동하는지 확인이 필요합니다.

## 참고사항

현재 CodeRabbit은 develop 브랜치로의 PR 병합 시에만 자동 리뷰를 진행했으나, feat/xx -> feat/yy와 같은 브랜치 간 PR 병합도 발생하므로 설정을 확장했습니다.