### PR TITLE
🐛 Fix: AuthPage를 FixedLayout 외부로 분리

### DIFF
--- a/apps/admin/src/app/main.tsx
+++ b/apps/admin/src/app/main.tsx
@@ -44,11 +44,11 @@ const router = createBrowserRouter([
         path: ROUTES.HOMEPAGE.NOTICE,
         element: <NoticePage />,
       },
-      {
-        path: ROUTES.LOGIN.ROOT,
-        element: <AuthPage />,
-      },
     ],
+  },
+  {
+    path: ROUTES.LOGIN,
+    element: <AuthPage />,
   },
 ])
 

--- a/apps/admin/src/shared/constant/routes.ts
+++ b/apps/admin/src/shared/constant/routes.ts
@@ -11,7 +11,5 @@ export const ROUTES = {
   HOMEPAGE: {
     NOTICE: '/homepage/notice',
   },
-  LOGIN: {
-    ROOT: '/login',
-  },
+  LOGIN: '/login',
 } as const


### PR DESCRIPTION
## 이슈 번호

Closes #146

## 작업 내용 및 테스트 방법

- 라우트 구조 수정
  - LOGIN 상수 객체 구조 → 문자열 구조로 변경
  - `/login` 경로 간소화

- AuthPage를 FixedLayout 외부로 분리
  - createBrowserRouter 배열에서 FixedLayout 외부로 AuthPage 분리
  - 로그인 페이지에서 헤더/LNB 미렌더링

- 렌더링 테스트로 FixedLayout(헤더/LNB) 제거 확인

## To reviewers

- 로그인 페이지에서 LNB 및 헤더가 완전히 제거되었는지 확인해주세요.
- 라우트 구조 변경으로 인한 다른 페이지에 영향이 없는지 확인해주세요.