### PR TITLE
🐛Fix: LogoHeader 컴포넌트 bg-white className 추가

### DIFF
--- a/packages/ui/src/header/logo-header.tsx
+++ b/packages/ui/src/header/logo-header.tsx
@@ -2,7 +2,7 @@ import { BbanggreuiOvenLogo } from '@dessert/icons'
 
 function LogoHeader() {
   return (
-    <header className="flex h-header max-w-[1920px] shrink-0 items-center border-b border-b-gray-300 px-24 py-10">
+    <header className="flex h-header max-w-[1920px] shrink-0 items-center border-b border-b-gray-300 bg-white px-24 py-10">
       <BbanggreuiOvenLogo />
     </header>
   )


### PR DESCRIPTION
## 이슈 번호

Closes #147

## 작업 내용 및 테스트 방법

- LogoHeader 컴포넌트에 bg-white className 추가
  - 디자인 시안과 코드의 불일치 해결

## To reviewers

- seller / admin 앱에서 LogoHeader 컴포넌트의 배경색이 흰색으로 정상 표시되는지 확인해주세요.