### PR TITLE
🐛 Fix: LNB 컴포넌트 스타일 수정

### DIFF
--- a/apps/admin/src/app/fixed-layout.tsx
+++ b/apps/admin/src/app/fixed-layout.tsx
@@ -10,7 +10,7 @@ const FixedLayout = () => {
       <LogoHeader />
       <div className="flex h-[calc(100vh-80px)] w-full flex-row overflow-y-auto">
         <Lnb />
-        <main className="size-full bg-gray-50 py-40">
+        <main className="min-w-0 flex-1 bg-gray-50 py-40">
           <ScrollArea.Root className="size-full">
             <ScrollArea.Viewport className="size-full px-22.5">
               <Outlet />

--- a/apps/admin/src/widgets/lnb/lnb.tsx
+++ b/apps/admin/src/widgets/lnb/lnb.tsx
@@ -35,14 +35,14 @@ export function Lnb() {
   return (
     <nav
       aria-label="관리자 메뉴"
-      className="relative flex h-[calc(100vh-80px)] w-[240px] flex-col border-r border-border"
+      className="relative flex h-[calc(100vh-80px)] w-[240px] shrink-0 flex-col border-r border-border"
     >
-      <div className="flex-1 overflow-y-auto px-3 py-4">
+      <div className="flex-1 overflow-y-auto px-10 py-16">
         <Accordion type="multiple" className="gap-10">
           {MENU_LIST.map((menu) => (
             <AccordionItem value={menu.group} key={menu.group}>
               <AccordionTrigger>
-                <span className="typo-title-16-m text-gray-800">
+                <span className="typo-title-16-sb text-gray-800">
                   {menu.group}
                 </span>
               </AccordionTrigger>


### PR DESCRIPTION
## 이슈 번호

Closes #152

## 작업 내용 및 테스트 방법

- LNB nav 요소 flex-shrink 문제 해결 (shrink-0 className 추가)

- Accordion 컨테이너 padding 수정 (px-3 py-4 → px-10 py-16)

- AccordionTrigger typography 수정 (typo-title-16-m → typo-title-16-sb)

## To reviewers

- LNB 컴포넌트의 너비가 240px로 정상 유지되는지 확인해주세요.
- Accordion 패딩과 텍스트 스타일이 디자인 시안과 일치하는지 확인이 필요합니다.

## 참고사항

LNB nav w-[240px] 미적용 문제는 형제 컴포넌트의 size-full className이 모든 공간을 차지하려 팽창하고, flex-shrink의 기본값(flex-shrink:1)에 의해 LNB 컴포넌트가 압축되는 현상입니다. shrink-0 className 추가로 해결했습니다.