### PR TITLE
🐛 Fix: Login API response type 수정 및 토큰 저장 문제 해결

### DIFF
--- a/apps/admin/src/entity/auth/auth.api.ts
+++ b/apps/admin/src/entity/auth/auth.api.ts
@@ -3,9 +3,16 @@ import { AxiosResponse } from 'axios'
 import { client } from '@/shared/utils'
 
 export interface LoginResponse {
-  accessToken: string
-  refreshToken: string
+  success: boolean
+  code: number
+  message: string
+  fieldErrors: Array<{ field: string; msg: string }>
+  result: {
+    accessToken: string
+    refreshToken: string
+  }
 }
+
 export const adminLogin = async (data: {
   accountId: string
   password: string

--- a/apps/admin/src/entity/auth/auth.api.ts
+++ b/apps/admin/src/entity/auth/auth.api.ts
@@ -1,8 +1,6 @@
-import { AxiosResponse } from 'axios'
-
 import { client } from '@/shared/utils'
 
-export interface LoginResponse {
+interface LoginResponse {
   success: boolean
   code: number
   message: string
@@ -10,12 +8,18 @@ export interface LoginResponse {
   result: {
     accessToken: string
     refreshToken: string
-  }
+  } | null
 }
 
 export const adminLogin = async (data: {
   accountId: string
   password: string
-}): Promise<AxiosResponse<LoginResponse>> => {
-  return await client.post('/api/v1/admin/login', data)
+}): Promise<{ accessToken: string; refreshToken: string }> => {
+  const response = await client.post<LoginResponse>('/api/v1/admin/login', data)
+
+  if (!response.data.success || !response.data.result) {
+    throw new Error(response.data.message)
+  }
+
+  return response.data.result
 }

--- a/apps/admin/src/features/auth/login.mutation.ts
+++ b/apps/admin/src/features/auth/login.mutation.ts
@@ -4,18 +4,12 @@ import { adminLogin, authKeys, useAuthStore } from '@/entity/auth'
 import { TOKEN_COOKIE_KEYS } from '@/shared/constant'
 import { getExpFromToken, setCookie } from '@/shared/utils'
 
-import { LoginFormValues } from './login.schema'
-
 export const useAdminLoginMutation = () => {
   const setIsLoggedIn = useAuthStore((state) => state.setIsLoggedIn)
 
   return useMutation({
     mutationKey: authKeys.all,
-    mutationFn: async (credentials: LoginFormValues) => {
-      const { data } = await adminLogin(credentials)
-
-      return data.result
-    },
+    mutationFn: adminLogin,
     onSuccess: ({ accessToken, refreshToken }) => {
       try {
         setCookie(

--- a/apps/admin/src/features/auth/login.mutation.ts
+++ b/apps/admin/src/features/auth/login.mutation.ts
@@ -4,15 +4,19 @@ import { adminLogin, authKeys, useAuthStore } from '@/entity/auth'
 import { TOKEN_COOKIE_KEYS } from '@/shared/constant'
 import { getExpFromToken, setCookie } from '@/shared/utils'
 
+import { LoginFormValues } from './login.schema'
+
 export const useAdminLoginMutation = () => {
   const setIsLoggedIn = useAuthStore((state) => state.setIsLoggedIn)
 
   return useMutation({
     mutationKey: authKeys.all,
-    mutationFn: adminLogin,
-    onSuccess: (response) => {
-      const { accessToken, refreshToken } = response.data
+    mutationFn: async (credentials: LoginFormValues) => {
+      const { data } = await adminLogin(credentials)
 
+      return data.result
+    },
+    onSuccess: ({ accessToken, refreshToken }) => {
       try {
         setCookie(
           TOKEN_COOKIE_KEYS.ACCESS,


### PR DESCRIPTION
## 이슈 번호

Closes #160

## 작업 내용 및 테스트 방법

- API response type을 명세서와 동일하게 수정
  - response wrapper 구조 추가 (success, code, message, fieldErrors)
  - accessToken/refreshToken을 result 객체로 래핑

- login mutation에서 토큰 추출 로직 수정
  - response.data → response.data.result로 변경
  - Parameter Destructuring으로 간결하게 구현
  - 토큰이 undefined가 아닌 실제 데이터로 저장되도록 수정

- 토큰이 정상적으로 cookie에 저장되는지 확인

## To reviewers

- 로그인 후 accessToken과 refreshToken이 정상적으로 cookie에 저장되는지 확인해주세요.
- API 명세서와 response 구조가 일치하는지 확인이 필요합니다.