### PR TITLE
🐛 Fix: 프로덕션 환경변수 이름 동기화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Admin App Build
         run: yarn run build:admin
         env:
-          VITE_API_BASE_URL: ${{secrets.ADMIN_API_BASE_URL}}
+          VITE_PUBLIC_SERVER_URL: ${{secrets.ADMIN_API_BASE_URL}}
 
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## 이슈 번호

Closes #162

## 작업 내용 및 테스트 방법

- CD GitHub Actions 파일에서 환경변수명 수정 (VITE_API_BASE_URL → VITE_PUBLIC_SERVER_URL)
- GitHub Repo Actions secrets에서 환경변수명 수정 (VITE_API_BASE_URL → VITE_PUBLIC_SERVER_URL)