### PR TITLE
♻️ Refactor: FSD 레이어 규칙 및 순환 의존성 위반 문제 개선

### DIFF
--- a/apps/admin/src/app/app.tsx
+++ b/apps/admin/src/app/app.tsx
@@ -6,6 +6,9 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom'
 import { Bounce, ToastContainer } from 'react-toastify'
 
 import { useAuthStore } from '@/entity/auth'
+import { setupAuthResponseInterceptor } from '@/shared/utils'
+
+setupAuthResponseInterceptor(() => useAuthStore.getState().logout())
 
 function App({ router }: { router: ReturnType<typeof createBrowserRouter> }) {
   const [queryClient] = useState(() => new QueryClient())

--- a/apps/admin/src/shared/utils/axios.ts
+++ b/apps/admin/src/shared/utils/axios.ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
 
-import { useAuthStore } from '@/entity/auth'
 import { TOKEN_COOKIE_KEYS } from '@/shared/constant'
 import { getCookie } from '@/shared/utils/cookieUtils'
 const baseURL = import.meta.env.VITE_PUBLIC_SERVER_URL
@@ -23,19 +22,26 @@ client.interceptors.request.use(
   (error) => Promise.reject(error),
 )
 
-client.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      const requestUrl = error.config?.url ?? ''
-      const isLoginRequest = /\/api\/v1\/admin\/login(?:\?|$)/.test(requestUrl)
-      // 로그인 요청의 401은 무시 (onError에서 처리)
-      if (!isLoginRequest) {
-        const { logout } = useAuthStore.getState()
-        logout()
-        window.location.href = '/login'
+type UnauthorizedCallback = () => void
+
+export const setupAuthResponseInterceptor = (
+  onUnauthorized: UnauthorizedCallback,
+) => {
+  client.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      if (error.response?.status === 401) {
+        const requestUrl = error.config?.url ?? ''
+        const isLoginRequest = /\/api\/v1\/admin\/login(?:\?|$)/.test(
+          requestUrl,
+        )
+        // 로그인 요청의 401은 무시 (onError에서 처리)
+        if (!isLoginRequest) {
+          onUnauthorized()
+          window.location.href = '/login'
+        }
       }
-    }
-    return Promise.reject(error)
-  },
-)
+      return Promise.reject(error)
+    },
+  )
+}

--- a/apps/admin/src/shared/utils/index.ts
+++ b/apps/admin/src/shared/utils/index.ts
@@ -5,4 +5,4 @@ export {
   getExpFromToken,
 } from './cookieUtils'
 
-export { client } from './axios'
+export { client, setupAuthResponseInterceptor } from './axios'


### PR DESCRIPTION
## 이슈 번호

Closes #156

## 작업 내용 및 테스트 방법

- axios response interceptor를 DI 패턴으로 리팩토링
  - setupAuthResponseInterceptor 함수로 분리
  - useAuthStore 직접 의존성 제거
  - onUnauthorized 콜백으로 의존성 주입

- 401 에러 처리 로직 유지 (로그인 요청 제외 및 리다이렉트)

- App 진입점에서 setupAuthResponseInterceptor 초기화
  - useAuthStore.getState().logout()을 콜백으로 주입

## To reviewers

- FSD cross import 규칙이 더 이상 위반되지 않는지 확인이 필요합니다.
- 순환 의존성 에러(eslint import/no-cycle)가 해결되었는지 확인해주세요.

## 참고사항

- DI 패턴 적용으로 axios 설정이 더 이상 useAuthStore에 직접 의존하지 않으므로, 테스트하기도 용이해졌습니다.
- 현재 login api 외에 다른 api가 존재하지 않아서, 인터셉터가 401 에러처리하는 과정을 확인할 수 없습니다. 다른 작업을 진행하면서 문제가 발생하면 알려주세요.