### PR TITLE
📦 Chore: 환경변수 설정 전체 동기화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   push:
-    branches: [develop]
+    branches: [ develop ]
   workflow_dispatch:
     inputs:
       deploy_seller:
@@ -52,7 +52,8 @@ jobs:
   # ─────────────────────────────────────
   deploy-seller:
     needs: detect-changes
-    if: needs.detect-changes.outputs.seller == 'true' || github.event.inputs.deploy_seller == 'true'
+    if: needs.detect-changes.outputs.seller == 'true' ||
+      github.event.inputs.deploy_seller == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +79,7 @@ jobs:
       - name: Seller App Build
         run: yarn run build:seller
         env:
-          VITE_API_BASE_URL: ${{secrets.SELLER_API_BASE_URL}}
+          VITE_PUBLIC_SERVER_URL: ${{secrets.VITE_PUBLIC_SERVER_URL}}
 
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -115,7 +116,8 @@ jobs:
   # ─────────────────────────────────────
   deploy-admin:
     needs: detect-changes
-    if: needs.detect-changes.outputs.admin == 'true' || github.event.inputs.deploy_admin == 'true'
+    if: needs.detect-changes.outputs.admin == 'true' ||
+      github.event.inputs.deploy_admin == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -141,7 +143,7 @@ jobs:
       - name: Admin App Build
         run: yarn run build:admin
         env:
-          VITE_PUBLIC_SERVER_URL: ${{secrets.ADMIN_API_BASE_URL}}
+          VITE_PUBLIC_SERVER_URL: ${{secrets.VITE_PUBLIC_SERVER_URL}}
 
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:8080
+VITE_PUBLIC_SERVER_URL=http://localhost:8080


### PR DESCRIPTION
## 이슈 번호

Closes #168

## 작업 내용 및 테스트 방법

- CI/CD 환경변수를 VITE_PUBLIC_SERVER_URL로 통일
  - seller: VITE_API_BASE_URL → VITE_PUBLIC_SERVER_URL
  - admin: ADMIN_API_BASE_URL → VITE_PUBLIC_SERVER_URL
  - 두 앱 모두 동일한 secrets 참조로 관리 간소화

- admin .env.example의 환경변수명 업데이트
  - VITE_API_BASE_URL → VITE_PUBLIC_SERVER_URL로 변경
  - 팀원들이 최신 환경변수명 기준으로 .env 설정 가능

## To reviewers

- CI/CD 배포 시 환경변수가 정상적으로 적용되는지 확인해주세요.
- 로컬 개발 환경에서도 VITE_PUBLIC_SERVER_URL로 작동하는지 확인이 필요합니다.
- seller와 admin 앱 모두 동일한 환경변수 체계를 따르는지 확인해주세요.

## 참고사항

환경변수 네이밍이 .env, .env.example, GitHub Actions secrets, CD 설정에서 모두 일관되게 통일되어 환경 관리의 혼동을 방지할 수 있습니다.