### PR TITLE
✨ Feat: 업로드 상품 승인(A03_101) Entity 도메인 정의 

### DIFF
--- a/apps/admin/src/entity/product/index.ts
+++ b/apps/admin/src/entity/product/index.ts
@@ -15,5 +15,3 @@ export {
 export { getUploadApprovals } from './product.api'
 
 export { productQueries } from './product.query'
-
-export { getProductMockData } from './product.mock'

--- a/apps/admin/src/entity/product/index.ts
+++ b/apps/admin/src/entity/product/index.ts
@@ -1,2 +1,19 @@
-export * from './product.type'
-export * from './product.mock'
+export type { Product, ProductOption, ProductResponse } from './product.type'
+export type {
+  UploadApproval,
+  UploadApprovalListResult,
+  GetUploadApprovalsRequestParams,
+} from './product.type'
+
+export {
+  UploadApprovalSchema,
+  UploadApprovalListResultSchema,
+  UploadApprovalListResponseSchema,
+  GetUploadApprovalsRequestParamsSchema,
+} from './product.contract'
+
+export { getUploadApprovals } from './product.api'
+
+export { productQueries } from './product.query'
+
+export { getProductMockData } from './product.mock'

--- a/apps/admin/src/entity/product/product.api.ts
+++ b/apps/admin/src/entity/product/product.api.ts
@@ -1,0 +1,20 @@
+import { getUploadApprovalMockData } from './product.mock'
+
+import type {
+  GetUploadApprovalsRequestParams,
+  UploadApprovalListResult,
+} from './product.type'
+
+export const getUploadApprovals = async (
+  params: GetUploadApprovalsRequestParams = {},
+): Promise<UploadApprovalListResult> => {
+  return getUploadApprovalMockData(params.page ?? 0, params.size ?? 20)
+
+  // TODO: DB 데이터 추가 후 아래 코드로 교체
+  // const response = await client.get('/api/v1/admin/products/upload-approvals', {
+  //   params,
+  // })
+  // const parsed = UploadApprovalListResponseSchema.parse(response.data)
+  // if (!parsed.success) throw new Error(parsed.message)
+  // return parsed.result
+}

--- a/apps/admin/src/entity/product/product.contract.ts
+++ b/apps/admin/src/entity/product/product.contract.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+export const UploadApprovalSchema = z.object({
+  boardId: z.number(),
+  storeName: z.string(),
+  boardTitle: z.string(),
+})
+
+export const UploadApprovalListResultSchema = z.object({
+  content: z.array(UploadApprovalSchema),
+  page: z.number(),
+  size: z.number(),
+  totalPages: z.number(),
+  totalElements: z.number(),
+})
+
+export const UploadApprovalListResponseSchema = z.object({
+  success: z.boolean(),
+  code: z.number(),
+  message: z.string(),
+  fieldErrors: z
+    .array(z.object({ field: z.string(), msg: z.string() }))
+    .optional(),
+  result: UploadApprovalListResultSchema,
+})
+
+export const GetUploadApprovalsRequestParamsSchema = z.object({
+  page: z.number().optional(),
+  size: z.number().optional(),
+  sort: z.array(z.string()).optional(),
+})

--- a/apps/admin/src/entity/product/product.contract.ts
+++ b/apps/admin/src/entity/product/product.contract.ts
@@ -1,31 +1,43 @@
 import { z } from 'zod'
 
 export const UploadApprovalSchema = z.object({
-  boardId: z.number(),
+  boardId: z.number().int().positive(),
   storeName: z.string(),
   boardTitle: z.string(),
 })
 
 export const UploadApprovalListResultSchema = z.object({
   content: z.array(UploadApprovalSchema),
-  page: z.number(),
-  size: z.number(),
-  totalPages: z.number(),
-  totalElements: z.number(),
+  page: z.number().int().nonnegative(),
+  size: z.number().int().positive(),
+  totalPages: z.number().int().nonnegative(),
+  totalElements: z.number().int().nonnegative(),
 })
 
-export const UploadApprovalListResponseSchema = z.object({
-  success: z.boolean(),
+const BaseResponseSchema = z.object({
   code: z.number(),
   message: z.string(),
   fieldErrors: z
     .array(z.object({ field: z.string(), msg: z.string() }))
     .optional(),
-  result: UploadApprovalListResultSchema,
 })
 
+export const UploadApprovalListResponseSchema = z.discriminatedUnion(
+  'success',
+  [
+    BaseResponseSchema.extend({
+      success: z.literal(true),
+      result: UploadApprovalListResultSchema,
+    }),
+    BaseResponseSchema.extend({
+      success: z.literal(false),
+      result: z.null().optional(),
+    }),
+  ],
+)
+
 export const GetUploadApprovalsRequestParamsSchema = z.object({
-  page: z.number().optional(),
-  size: z.number().optional(),
+  page: z.number().int().nonnegative().optional(),
+  size: z.number().int().positive().optional(),
   sort: z.array(z.string()).optional(),
 })

--- a/apps/admin/src/entity/product/product.mock.ts
+++ b/apps/admin/src/entity/product/product.mock.ts
@@ -1,5 +1,7 @@
 import { Product } from './product.type'
 
+import type { UploadApproval } from './product.type'
+
 const STORES = [
   '그린베이커리',
   '달빛빵집',
@@ -72,5 +74,96 @@ export const getProductMockData = (page: number, size: number) => {
   return {
     data: ALL_MOCK_DATA.slice(start, end),
     totalCount: ALL_MOCK_DATA.length,
+  }
+}
+
+const UPLOAD_APPROVAL_MOCK_DATA: UploadApproval[] = [
+  { boardId: 1, storeName: '그린베이커리', boardTitle: '비건 통밀 식빵' },
+  { boardId: 2, storeName: '달빛빵집', boardTitle: '저당 스콘 세트' },
+  { boardId: 3, storeName: '디저트팩토리', boardTitle: '글루텐프리 쿠키' },
+  { boardId: 4, storeName: '오븐브라더스', boardTitle: '고단백 케이크' },
+  { boardId: 5, storeName: '슈가플래닛', boardTitle: '저지방 타르트' },
+  { boardId: 6, storeName: '그린베이커리', boardTitle: '비건 휘낭시에' },
+  { boardId: 7, storeName: '달빛빵집', boardTitle: '저당 마들렌' },
+  { boardId: 8, storeName: '디저트팩토리', boardTitle: '글루텐프리 까눌레' },
+  { boardId: 9, storeName: '오븐브라더스', boardTitle: '고단백 파운드케이크' },
+  { boardId: 10, storeName: '슈가플래닛', boardTitle: '저지방 스콘 모둠' },
+  { boardId: 11, storeName: '그린베이커리', boardTitle: '비건 쿠키 박스' },
+  { boardId: 12, storeName: '달빛빵집', boardTitle: '저당 케이크 조각' },
+  { boardId: 13, storeName: '디저트팩토리', boardTitle: '글루텐프리 타르트' },
+  { boardId: 14, storeName: '오븐브라더스', boardTitle: '고단백 식빵 2종' },
+  { boardId: 15, storeName: '슈가플래닛', boardTitle: '저지방 마들렌 세트' },
+  { boardId: 16, storeName: '그린베이커리', boardTitle: '비건 까눌레 6개입' },
+  { boardId: 17, storeName: '달빛빵집', boardTitle: '저당 파운드케이크' },
+  { boardId: 18, storeName: '디저트팩토리', boardTitle: '글루텐프리 휘낭시에' },
+  { boardId: 19, storeName: '오븐브라더스', boardTitle: '고단백 쿠키 모둠' },
+  { boardId: 20, storeName: '슈가플래닛', boardTitle: '저지방 케이크 롤' },
+  { boardId: 21, storeName: '그린베이커리', boardTitle: '비건 단팥빵' },
+  { boardId: 22, storeName: '달빛빵집', boardTitle: '저당 크로와상' },
+  { boardId: 23, storeName: '디저트팩토리', boardTitle: '글루텐프리 베이글' },
+  { boardId: 24, storeName: '오븐브라더스', boardTitle: '고단백 브라우니' },
+  { boardId: 25, storeName: '슈가플래닛', boardTitle: '저지방 머핀 세트' },
+  { boardId: 26, storeName: '그린베이커리', boardTitle: '비건 바나나 브레드' },
+  { boardId: 27, storeName: '달빛빵집', boardTitle: '저당 레몬 타르트' },
+  {
+    boardId: 28,
+    storeName: '디저트팩토리',
+    boardTitle: '글루텐프리 초코 쿠키',
+  },
+  { boardId: 29, storeName: '오븐브라더스', boardTitle: '고단백 그래놀라 바' },
+  { boardId: 30, storeName: '슈가플래닛', boardTitle: '저지방 딸기 케이크' },
+  { boardId: 31, storeName: '그린베이커리', boardTitle: '비건 호두 파운드' },
+  { boardId: 32, storeName: '달빛빵집', boardTitle: '저당 말차 휘낭시에' },
+  {
+    boardId: 33,
+    storeName: '디저트팩토리',
+    boardTitle: '글루텐프리 아몬드 스콘',
+  },
+  { boardId: 34, storeName: '오븐브라더스', boardTitle: '고단백 단호박 식빵' },
+  { boardId: 35, storeName: '슈가플래닛', boardTitle: '저지방 블루베리 머핀' },
+  { boardId: 36, storeName: '그린베이커리', boardTitle: '비건 코코넛 마카롱' },
+  { boardId: 37, storeName: '달빛빵집', boardTitle: '저당 얼그레이 케이크' },
+  {
+    boardId: 38,
+    storeName: '디저트팩토리',
+    boardTitle: '글루텐프리 오트밀 쿠키',
+  },
+  { boardId: 39, storeName: '오븐브라더스', boardTitle: '고단백 치즈 베이글' },
+  { boardId: 40, storeName: '슈가플래닛', boardTitle: '저지방 복숭아 타르트' },
+  { boardId: 41, storeName: '그린베이커리', boardTitle: '비건 흑임자 마들렌' },
+  { boardId: 42, storeName: '달빛빵집', boardTitle: '저당 팥 도넛' },
+  { boardId: 43, storeName: '디저트팩토리', boardTitle: '글루텐프리 카스텔라' },
+  {
+    boardId: 44,
+    storeName: '오븐브라더스',
+    boardTitle: '고단백 두부 브라우니',
+  },
+  { boardId: 45, storeName: '슈가플래닛', boardTitle: '저지방 요거트 케이크' },
+  { boardId: 46, storeName: '그린베이커리', boardTitle: '비건 쑥 인절미 롤' },
+  { boardId: 47, storeName: '달빛빵집', boardTitle: '저당 자몽 치즈케이크' },
+  {
+    boardId: 48,
+    storeName: '디저트팩토리',
+    boardTitle: '글루텐프리 퀴노아 크래커',
+  },
+  { boardId: 49, storeName: '오븐브라더스', boardTitle: '고단백 에그 타르트' },
+  {
+    boardId: 50,
+    storeName: '슈가플래닛',
+    boardTitle: '저지방 망고 무스케이크',
+  },
+]
+
+export const getUploadApprovalMockData = (page: number, size: number) => {
+  const safePage = Math.max(0, page)
+  const safeSize = Math.max(1, size)
+  const start = safePage * safeSize
+  const end = start + safeSize
+  return {
+    content: UPLOAD_APPROVAL_MOCK_DATA.slice(start, end),
+    page: safePage,
+    size: safeSize,
+    totalElements: UPLOAD_APPROVAL_MOCK_DATA.length,
+    totalPages: Math.ceil(UPLOAD_APPROVAL_MOCK_DATA.length / safeSize),
   }
 }

--- a/apps/admin/src/entity/product/product.query.ts
+++ b/apps/admin/src/entity/product/product.query.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from '@tanstack/react-query'
+
+import { getUploadApprovals } from './product.api'
+
+import type { GetUploadApprovalsRequestParams } from './product.type'
+
+export const productQueries = {
+  all: () => ['products'] as const,
+  uploadApprovals: () => [...productQueries.all(), 'upload-approvals'] as const,
+
+  uploadApprovalList: (params: GetUploadApprovalsRequestParams = {}) =>
+    queryOptions({
+      queryKey: [...productQueries.uploadApprovals(), params],
+      queryFn: () => getUploadApprovals(params),
+    }),
+}

--- a/apps/admin/src/entity/product/product.type.ts
+++ b/apps/admin/src/entity/product/product.type.ts
@@ -1,3 +1,10 @@
+import type {
+  GetUploadApprovalsRequestParamsSchema,
+  UploadApprovalListResultSchema,
+  UploadApprovalSchema,
+} from './product.contract'
+import type { z } from 'zod'
+
 export interface ProductOption {
   optionId: number
   optionName: string
@@ -26,3 +33,11 @@ export interface ProductResponse {
     totalPages: number
   }
 }
+
+export type UploadApproval = z.infer<typeof UploadApprovalSchema>
+export type UploadApprovalListResult = z.infer<
+  typeof UploadApprovalListResultSchema
+>
+export type GetUploadApprovalsRequestParams = z.infer<
+  typeof GetUploadApprovalsRequestParamsSchema
+>


### PR DESCRIPTION
## 이슈 번호

Closes #158

## 작업 내용 및 테스트 방법

- 업로드 상품 승인 entity 생성 및 타입 정의
  - UploadApprovalSchema, UploadApprovalListResultSchema 정의
  - z.infer로 zod schema에서 TypeScript 타입 자동 추론

- 업로드 상품 승인 API 및 Query 정의
  - getUploadApprovals API (페이지네이션 지원)
  - productQueries 객체로 queryKey/queryFn 계층적 관리

- 업로드 상품 승인 mock data 정의
  - 5개 스토어의 50개 상품 정보 데이터
  - page, size 기반 페이지네이션 처리

- product entity Public API 명시적 정의
  - wildcard export → named export로 변경
  - 의도하지 않은 의존성 생성 방지

## To reviewers

- Schema 정의가 실제 API 응답 구조와 일치하는지 확인해주세요.
- Public API에서 의도하지 않은 타입이 노출되지 않는지 확인해주세요.