### PR TITLE
✨ Feat: 업로드 상품 승인(A03_101) 테이블 기능 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -144,6 +144,7 @@ jobs:
         run: yarn run build:admin
         env:
           VITE_PUBLIC_SERVER_URL: ${{secrets.VITE_PUBLIC_SERVER_URL}}
+          VITE_PUBLIC_CUSTOMER_URL: ${{secrets.VITE_PUBLIC_CUSTOMER_URL}}
 
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,1 +1,2 @@
 VITE_PUBLIC_SERVER_URL=http://localhost:8080
+VITE_PUBLIC_CUSTOMER_URL=http://localhost:3000

--- a/apps/admin/src/entity/product/product.api.ts
+++ b/apps/admin/src/entity/product/product.api.ts
@@ -1,4 +1,6 @@
-import { getUploadApprovalMockData } from './product.mock'
+import { client } from '@/shared/utils'
+
+import { UploadApprovalListResponseSchema } from './product.contract'
 
 import type {
   GetUploadApprovalsRequestParams,
@@ -8,13 +10,10 @@ import type {
 export const getUploadApprovals = async (
   params: GetUploadApprovalsRequestParams = {},
 ): Promise<UploadApprovalListResult> => {
-  return getUploadApprovalMockData(params.page ?? 0, params.size ?? 20)
-
-  // TODO: DB 데이터 추가 후 아래 코드로 교체
-  // const response = await client.get('/api/v1/admin/products/upload-approvals', {
-  //   params,
-  // })
-  // const parsed = UploadApprovalListResponseSchema.parse(response.data)
-  // if (!parsed.success) throw new Error(parsed.message)
-  // return parsed.result
+  const response = await client.get('/api/v1/admin/products/upload-approvals', {
+    params,
+  })
+  const parsed = UploadApprovalListResponseSchema.parse(response.data)
+  if (!parsed.success) throw new Error(parsed.message)
+  return parsed.result
 }

--- a/apps/admin/src/features/product/upload-approval/index.ts
+++ b/apps/admin/src/features/product/upload-approval/index.ts
@@ -1,0 +1,1 @@
+export { UploadApprovalTable } from './upload-approval-table.ui'

--- a/apps/admin/src/features/product/upload-approval/upload-approval-action-group.ui.tsx
+++ b/apps/admin/src/features/product/upload-approval/upload-approval-action-group.ui.tsx
@@ -1,0 +1,24 @@
+import { Pagination } from '@dessert/ui'
+
+interface UploadApprovalActionGroupProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+export const UploadApprovalActionGroup = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: UploadApprovalActionGroupProps) => {
+  return (
+    <div className="flex w-full items-center justify-between">
+      <div />
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={onPageChange}
+      />
+    </div>
+  )
+}

--- a/apps/admin/src/features/product/upload-approval/upload-approval-table.ui.tsx
+++ b/apps/admin/src/features/product/upload-approval/upload-approval-table.ui.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 
 import { Button, Table } from '@dessert/ui'
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { ColumnDef } from '@tanstack/react-table'
 
 import { UploadApproval, productQueries } from '@/entity/product'
@@ -12,15 +12,20 @@ const PAGE_SIZE = 10
 const HEADER_CLASS = 'border-b-[0.8px] border-b-gray-400'
 const CUSTOMER_URL = import.meta.env.VITE_PUBLIC_CUSTOMER_URL
 
+if (!CUSTOMER_URL) {
+  throw new Error('VITE_PUBLIC_CUSTOMER_URL 환경변수가 설정되지 않았습니다.')
+}
+
 export const UploadApprovalTable = () => {
   const [currentPage, setCurrentPage] = useState(1)
 
-  const { data, isLoading } = useQuery(
-    productQueries.uploadApprovalList({
+  const { data } = useQuery({
+    ...productQueries.uploadApprovalList({
       page: currentPage - 1,
       size: PAGE_SIZE,
     }),
-  )
+    placeholderData: keepPreviousData,
+  })
 
   const handleApprove = (boardId: number) => {
     alert(`승인: ${boardId}`)
@@ -93,8 +98,6 @@ export const UploadApprovalTable = () => {
     ],
     [currentPage],
   )
-
-  if (isLoading) return null
 
   return (
     <Table

--- a/apps/admin/src/features/product/upload-approval/upload-approval-table.ui.tsx
+++ b/apps/admin/src/features/product/upload-approval/upload-approval-table.ui.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { Button, Table } from '@dessert/ui'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
@@ -27,13 +27,13 @@ export const UploadApprovalTable = () => {
     placeholderData: keepPreviousData,
   })
 
-  const handleApprove = (boardId: number) => {
+  const handleApprove = useCallback((boardId: number) => {
     alert(`승인: ${boardId}`)
-  }
+  }, [])
 
-  const handleReject = (boardId: number) => {
+  const handleReject = useCallback((boardId: number) => {
     alert(`거절: ${boardId}`)
-  }
+  }, [])
 
   const columns = useMemo<ColumnDef<UploadApproval>[]>(
     () => [
@@ -64,7 +64,7 @@ export const UploadApprovalTable = () => {
         meta: { headerClassName: HEADER_CLASS, flexible: true },
         cell: ({ row }) => (
           <a
-            href={`${CUSTOMER_URL}/main/products/${row.original.boardId}/info`}
+            href={`${CUSTOMER_URL}/main/products/${encodeURIComponent(row.original.boardId)}/info`}
             target="_blank"
             rel="noopener noreferrer"
             className="typo-title-14-r text-primary-500 underline"
@@ -96,7 +96,7 @@ export const UploadApprovalTable = () => {
         size: 130,
       },
     ],
-    [currentPage],
+    [currentPage, handleApprove, handleReject],
   )
 
   return (
@@ -107,7 +107,7 @@ export const UploadApprovalTable = () => {
       topArea={
         <UploadApprovalActionGroup
           currentPage={currentPage}
-          totalPages={data?.totalPages ?? 1}
+          totalPages={data?.totalPages || 0}
           onPageChange={setCurrentPage}
         />
       }

--- a/apps/admin/src/features/product/upload-approval/upload-approval-table.ui.tsx
+++ b/apps/admin/src/features/product/upload-approval/upload-approval-table.ui.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react'
+
+import { Button, Table } from '@dessert/ui'
+import { useQuery } from '@tanstack/react-query'
+import { ColumnDef } from '@tanstack/react-table'
+
+import { UploadApproval, productQueries } from '@/entity/product'
+
+import { UploadApprovalActionGroup } from './upload-approval-action-group.ui'
+
+const PAGE_SIZE = 10
+const HEADER_CLASS = 'border-b-[0.8px] border-b-gray-400'
+const CUSTOMER_URL = import.meta.env.VITE_PUBLIC_CUSTOMER_URL
+
+export const UploadApprovalTable = () => {
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const { data, isLoading } = useQuery(
+    productQueries.uploadApprovalList({
+      page: currentPage - 1,
+      size: PAGE_SIZE,
+    }),
+  )
+
+  const handleApprove = (boardId: number) => {
+    alert(`승인: ${boardId}`)
+  }
+
+  const handleReject = (boardId: number) => {
+    alert(`거절: ${boardId}`)
+  }
+
+  const columns = useMemo<ColumnDef<UploadApproval>[]>(
+    () => [
+      {
+        id: 'no',
+        header: 'NO',
+        meta: { headerClassName: HEADER_CLASS },
+        cell: ({ row }) => (
+          <span className="typo-title-14-r text-gray-900">
+            {(currentPage - 1) * PAGE_SIZE + row.index + 1}
+          </span>
+        ),
+        size: 70,
+      },
+      {
+        accessorKey: 'storeName',
+        header: '변경 전 스토어명',
+        meta: { headerClassName: HEADER_CLASS, flexible: true },
+        cell: ({ row }) => (
+          <span className="typo-title-14-r text-gray-900 underline">
+            {row.original.storeName}
+          </span>
+        ),
+      },
+      {
+        accessorKey: 'boardTitle',
+        header: '상품명',
+        meta: { headerClassName: HEADER_CLASS, flexible: true },
+        cell: ({ row }) => (
+          <a
+            href={`${CUSTOMER_URL}/main/products/${row.original.boardId}/info`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="typo-title-14-r text-primary-500 underline"
+          >
+            {row.original.boardTitle}
+          </a>
+        ),
+      },
+      {
+        id: 'actions',
+        header: '승인/거절',
+        meta: { headerClassName: HEADER_CLASS },
+        cell: ({ row }) => (
+          <div className="flex items-center justify-center gap-8">
+            <Button
+              title="승인"
+              size="sm"
+              variant="primary-outlined"
+              onClick={() => handleApprove(row.original.boardId)}
+            />
+            <Button
+              title="거절"
+              size="sm"
+              variant="secondary-outlined"
+              onClick={() => handleReject(row.original.boardId)}
+            />
+          </div>
+        ),
+        size: 130,
+      },
+    ],
+    [currentPage],
+  )
+
+  if (isLoading) return null
+
+  return (
+    <Table
+      data={data?.content ?? []}
+      columns={columns}
+      tableClassName="w-full table-fixed"
+      topArea={
+        <UploadApprovalActionGroup
+          currentPage={currentPage}
+          totalPages={data?.totalPages ?? 1}
+          onPageChange={setCurrentPage}
+        />
+      }
+    />
+  )
+}

--- a/apps/admin/src/pages/product/upload-approval/upload-approval-page.tsx
+++ b/apps/admin/src/pages/product/upload-approval/upload-approval-page.tsx
@@ -1,3 +1,5 @@
+import { UploadApprovalTable } from '@/features/product/upload-approval'
+
 export function UploadApprovalPage() {
-  return <div>UploadApprovalPage</div>
+  return <UploadApprovalTable />
 }

--- a/packages/ui/src/table/table.tsx
+++ b/packages/ui/src/table/table.tsx
@@ -14,6 +14,7 @@ declare module '@tanstack/react-table' {
     getColSpan?: (cell: Cell<TData, TValue>) => number
     className?: string
     headerClassName?: string
+    flexible?: boolean
   }
 }
 
@@ -22,6 +23,7 @@ interface TableProps<T> {
   columns: ColumnDef<T>[]
   topArea?: React.ReactNode
   maxHeight?: string | number
+  tableClassName?: string
   getRowClassName?: (row: T) => string
   renderSubRow?: (row: T) => React.ReactNode
 }
@@ -31,6 +33,7 @@ function Table<T>({
   columns,
   topArea,
   maxHeight = '600px',
+  tableClassName,
   getRowClassName,
   renderSubRow,
 }: TableProps<T>) {
@@ -49,7 +52,7 @@ function Table<T>({
         </div>
       )}
       <div className="overflow-auto" style={{ maxHeight: maxHeight }}>
-        <table className="min-w-max border-collapse">
+        <table className={cn('border-collapse', tableClassName ?? 'min-w-max')}>
           <thead className="sticky top-0 z-10 bg-gray-200">
             {getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id} className="h-40">
@@ -61,14 +64,18 @@ function Table<T>({
                       'text-center align-middle typo-body-12-m text-gray-800',
                       header.column.columnDef.meta?.headerClassName,
                     )}
-                    style={{ width: header.getSize() }}
+                    style={
+                      header.column.columnDef.meta?.flexible
+                        ? undefined
+                        : { width: header.getSize() }
+                    }
                   >
                     {header.isPlaceholder ? null : (
                       <>
                         {flexRender(
                           header.column.columnDef.header,
                           header.getContext(),
-                        ) || '\u00A0'}
+                        ) || ' '}
                       </>
                     )}
                   </th>
@@ -105,7 +112,11 @@ function Table<T>({
                           'border-r border-r-gray-300 text-center align-middle last:border-r-0',
                           cell.column.columnDef.meta?.className,
                         )}
-                        style={{ width: cell.column.getSize() }}
+                        style={
+                          cell.column.columnDef.meta?.flexible
+                            ? undefined
+                            : { width: cell.column.getSize() }
+                        }
                       >
                         <div className="p-10">
                           {flexRender(


### PR DESCRIPTION
## 이슈 번호

Closes #175

## 작업 내용 및 테스트 방법

- getUploadApprovals API mock → 실제 API 전환
  - /api/v1/admin/products/upload-approvals 엔드포인트 호출
  - UploadApprovalListResponseSchema로 응답 검증

- Table 컴포넌트 유연성 개선
  - flexible 옵션으로 특정 열의 너비를 동적으로 설정
  - tableClassName prop 추가로 테이블 커스터마이징 지원
  - backward compatible (기존 호출부 영향 없음)

- 업로드 상품 승인 테이블 UI 구현
  - UploadApprovalTable (NO, 스토어명, 상품명, 액션 4개 컬럼)
  - flexible 옵션으로 storeName, boardTitle 열의 너비 유동처리
  - UploadApprovalActionGroup (페이지네이션 컨트롤)
  - 상품명 클릭 시 고객 페이지로 이동

- 고객 페이지 URL 환경 변수 추가
  - admin/.env.example에 VITE_PUBLIC_CUSTOMER_URL 추가
  - CD 워크플로우에 secrets 연결

## 환경변수 변경사항

- `VITE_PUBLIC_CUSTOMER_URL`: 고객 서비스 URL. 업로드 상품 승인 테이블에서 상품명 클릭 시 고객 페이지로 이동하는 링크 생성에 사용됩니다.

## To reviewers

- 실제 API 데이터가 테이블에 정상적으로 표시되는지 확인이 필요합니다.
  - (승인/거절 버튼 동작은 Issue #176, #177 에서 구현 예정으로 현재 미완성 상태입니다.)
- 페이지네이션이 정상 작동하는지 확인해주세요.
- 상품명 클릭 시 고객 페이지로의 링크가 올바르게 생성되는지 확인해주세요.
- UI 패키지 Table 컴포넌트 변경이 seller 앱 기존 테이블에 영향을 주지 않는지 확인해주세요.

## 참고사항

- `packages/ui` Table 공통 컴포넌트 변경(`flexible`, `tableClassName` prop 추가)이 이 브랜치에 함께 포함되어 있습니다.
  별도 브랜치로 분리할 경우 PR 병합 순서 의존성이 생겨 작업 복잡도가 높아지고,
  변경 범위가 작고 이 기능 구현에만 필요한 수정이므로 함께 포함하였습니다.
- 추가된 prop은 모두 optional이며 기존 호출부에 영향을 주지 않습니다(backward compatible).
  seller 앱의 기존 Table 사용처는 prop 미전달 시 기존과 동일하게 동작합니다.
- `handleApprove`, `handleReject`는 현재 alert으로 구현되어 있으며,
  실제 승인/거절 API 연동은 Issue #176 , #177 에서 진행될 예정입니다.
- `스토어명` 컬럼은 현재 BE API Response에 `storeId`가 포함되지 않아
  링크 연결 없이 텍스트로만 표시되어 있습니다. BE 팀에 문의 중이며, 응답 확인 후 별도 작업 예정입니다.