### PR TITLE
✨ Feat: 주문 도메인 Entity 레이어 구현

### DIFF
--- a/apps/seller/src/entity/order/completed-order.mock.ts
+++ b/apps/seller/src/entity/order/completed-order.mock.ts
@@ -327,10 +327,14 @@ export function filterCompletedOrders(
 
   // 날짜 필터
   if (filters.startDate) {
-    result = result.filter((o) => o.paymentDate >= filters.startDate!)
+    result = result.filter(
+      (o) => o.paymentDate !== null && o.paymentDate >= filters.startDate!,
+    )
   }
   if (filters.endDate) {
-    result = result.filter((o) => o.paymentDate <= filters.endDate!)
+    result = result.filter(
+      (o) => o.paymentDate !== null && o.paymentDate <= filters.endDate!,
+    )
   }
 
   // 검색 키워드 필터
@@ -356,12 +360,12 @@ export function filterCompletedOrders(
 
   // 정렬
   if (filters.sort === 'ASC') {
-    result = [...result].sort(
-      (a, b) => a.paymentDate.localeCompare(b.paymentDate),
+    result = [...result].sort((a, b) =>
+      (a.paymentDate ?? '').localeCompare(b.paymentDate ?? ''),
     )
   } else {
-    result = [...result].sort(
-      (a, b) => b.paymentDate.localeCompare(a.paymentDate),
+    result = [...result].sort((a, b) =>
+      (b.paymentDate ?? '').localeCompare(a.paymentDate ?? ''),
     )
   }
 

--- a/apps/seller/src/entity/order/order.api.ts
+++ b/apps/seller/src/entity/order/order.api.ts
@@ -33,7 +33,10 @@ import {
   ShipmentRequest,
   UpdateShipmentResult,
 } from './order.type'
-import { DELIVERY_STATUS_MAP } from '@/entity/order/order.constant.ts'
+import {
+  DELIVERY_STATUS_MAP,
+  TAB_TO_STATUS,
+} from '@/entity/order/order.constant.ts'
 
 export interface UpdateOrderStatusRequest {
   orderNumbers: string[]
@@ -69,16 +72,6 @@ export async function getOrders(
   } = filters
 
   const today = new Date().toISOString().split('T')[0]
-
-  const TAB_TO_STATUS: Partial<Record<string, string>> = {
-    paymentCompleted: 'PAYMENT_COMPLETED',
-    orderConfirmed: 'ORDER_CONFIRMED',
-    productShipped: 'PRODUCT_SHIPPED',
-    deliveryCompleted: 'DELIVERY_COMPLETED',
-    canceled: 'CANCELED',
-    returned: 'RETURNED',
-    exchanged: 'EXCHANGED',
-  }
 
   const { data } = await client.post<ApiResponse<OrderListResult>>(
     '/api/v1/seller/orders/list',

--- a/apps/seller/src/entity/order/order.api.ts
+++ b/apps/seller/src/entity/order/order.api.ts
@@ -131,7 +131,7 @@ function toOrderItem(item: OrderListContent): OrderItem {
 
   return {
     recipientName: item.recipientName,
-    orderNumber: item.orderNumber,
+    orderNumber: String(item.orderNumber),
     products: item.orderItems.map((i) => ({
       productName: i.orderItemInfo.itemName,
       optionName: null,
@@ -156,11 +156,16 @@ function toOrderItem(item: OrderListContent): OrderItem {
 }
 
 export async function getOrderDetails(
-  orderItemIds: number[],
+  orderNumbers: string[],
 ): Promise<OrderDetail[]> {
   if (useMock) {
-    return getMockOrderDetailResponse(orderItemIds)
+    return getMockOrderDetailResponse(orderNumbers)
   }
+
+  // 서버 스펙: orderItemIds: number[] (int64). FE는 string으로 들고 다니다 wire에서만 변환
+  const orderItemIds = orderNumbers
+    .map((n) => Number(n))
+    .filter((n) => Number.isFinite(n))
 
   const { data } = await client.post<ApiResponse<OrderDetail[]>>(
     '/api/v1/seller/orders/items',

--- a/apps/seller/src/entity/order/order.api.ts
+++ b/apps/seller/src/entity/order/order.api.ts
@@ -208,6 +208,9 @@ export async function updateOrderStatus(
   })
 }
 
+// NOTE: 운송장 API의 응답 envelope 키가 백엔드 스펙상
+// POST(등록) = result.content (단수), PUT(수정) = result.contents (복수)로 갈림.
+// 오타가 아니라 의도된 차이.
 export async function createShipment(
   request: ShipmentRequest,
 ): Promise<CreateShipmentResult> {

--- a/apps/seller/src/entity/order/order.api.ts
+++ b/apps/seller/src/entity/order/order.api.ts
@@ -33,6 +33,7 @@ import {
   ShipmentRequest,
   UpdateShipmentResult,
 } from './order.type'
+import { DELIVERY_STATUS_MAP } from '@/entity/order/order.constant.ts'
 
 export interface UpdateOrderStatusRequest {
   orderNumbers: string[]
@@ -103,14 +104,6 @@ export async function getOrders(
   }
 
   return transformOrderListResult(data.result)
-}
-
-const DELIVERY_STATUS_MAP: Record<OrderDeliveryStatusSpec, DeliveryStatus> = {
-  PREPARING: 'PRODUCT_PREPARING',
-  COLLECTING: 'COLLECTING',
-  COLLECT_COMPLETED: 'COLLECT_COMPLETED',
-  DELIVERING: 'DELIVERING',
-  DELIVERY_COMPLETED: 'DELIVERY_COMPLETED',
 }
 
 function transformOrderListResult(result: OrderListResult): OrderListResponse {

--- a/apps/seller/src/entity/order/order.api.ts
+++ b/apps/seller/src/entity/order/order.api.ts
@@ -1,14 +1,37 @@
+import type { ApiResponse } from '@/entity/auth/types'
 import { client } from '@/shared/utils/axios'
 
 import {
+  getMockConfirmOrderResponse,
+  getMockCreateExchangeResponse,
+  getMockCreateReturnResponse,
+  getMockCreateShipmentResponse,
   getMockOrderDetailResponse,
   getMockOrderListResponse,
+  getMockUpdateShipmentResponse,
 } from './order.mock'
 import {
+  CancelDecisionRequest,
+  ConfirmOrderRequest,
+  ConfirmOrderResult,
   CourierName,
-  OrderDetailResponse,
+  CreateExchangeRequest,
+  CreateExchangeResult,
+  CreateReturnRequest,
+  CreateReturnResult,
+  CreateShipmentResult,
+  DeliveryStatus,
+  OrderDeliveryStatusSpec,
+  OrderDetail,
   OrderFilters,
+  OrderItem,
+  OrderListContent,
   OrderListResponse,
+  OrderListResult,
+  OrderStatusCount,
+  ReturnDecisionRequest,
+  ShipmentRequest,
+  UpdateShipmentResult,
 } from './order.type'
 
 export interface UpdateOrderStatusRequest {
@@ -18,17 +41,13 @@ export interface UpdateOrderStatusRequest {
   images?: File[]
 }
 
-export interface UpdateTrackingRequest {
-  orderNumber: string
-  courierName: CourierName
-  trackingNumber: string
-}
-
 export interface CompleteOrderRequest {
   orderNumbers: string[]
 }
 
-const useMock = import.meta.env.VITE_USE_MOCK === 'true'
+// VITE_USE_MOCK=true 일 때 mock 응답 사용
+// 미설정(false) 기타 값이면 실서버호출
+const useMock = import.meta.env.VITE_USE_MOCK === 'false'
 
 export async function getOrders(
   filters: OrderFilters,
@@ -50,8 +69,7 @@ export async function getOrders(
 
   const today = new Date().toISOString().split('T')[0]
 
-  const TAB_TO_STATUS: Record<string, string> = {
-    all: 'NONE',
+  const TAB_TO_STATUS: Partial<Record<string, string>> = {
     paymentCompleted: 'PAYMENT_COMPLETED',
     orderConfirmed: 'ORDER_CONFIRMED',
     productShipped: 'PRODUCT_SHIPPED',
@@ -61,10 +79,10 @@ export async function getOrders(
     exchanged: 'EXCHANGED',
   }
 
-  const { data } = await client.post<OrderListResponse>(
+  const { data } = await client.post<ApiResponse<OrderListResult>>(
     '/api/v1/seller/orders/list',
     {
-      orderStatus: TAB_TO_STATUS[tab ?? 'all'] ?? 'NONE',
+      orderStatus: tab ? (TAB_TO_STATUS[tab] ?? null) : null,
       searchType: searchType ?? 'BUYER_NAME',
       keywords: searchKeyword ? [searchKeyword] : [],
       isMultipleSearch: false,
@@ -79,21 +97,95 @@ export async function getOrders(
       },
     },
   )
-  return data
+
+  if (!data.result) {
+    throw new Error(data.message ?? '주문 목록 조회에 실패했습니다.')
+  }
+
+  return transformOrderListResult(data.result)
+}
+
+const DELIVERY_STATUS_MAP: Record<OrderDeliveryStatusSpec, DeliveryStatus> = {
+  PREPARING: 'PRODUCT_PREPARING',
+  COLLECTING: 'COLLECTING',
+  COLLECT_COMPLETED: 'COLLECT_COMPLETED',
+  DELIVERING: 'DELIVERING',
+  DELIVERY_COMPLETED: 'DELIVERY_COMPLETED',
+}
+
+function transformOrderListResult(result: OrderListResult): OrderListResponse {
+  const { orders, statusCounts } = result
+
+  const mappedStatusCount: OrderStatusCount = {
+    total: statusCounts.total,
+    paymentCompleted: statusCounts.paymentCompleted,
+    orderConfirmed: statusCounts.orderConfirmed,
+    productShipped: statusCounts.shipped,
+    deliveryCompleted: statusCounts.deliveryCompleted,
+    canceled: statusCounts.cancelled,
+    returned: statusCounts.returned,
+    exchanged: statusCounts.exchanged,
+  }
+
+  return {
+    statusCount: mappedStatusCount,
+    content: orders.content.map(toOrderItem),
+    page: orders.page,
+    size: orders.size,
+    totalPages: orders.totalPages,
+    totalElements: orders.totalElements,
+  }
+}
+
+function toOrderItem(item: OrderListContent): OrderItem {
+  const first = item.orderItems[0]
+  const courier = first?.courierCompany
+  const validCourier =
+    courier && courier !== 'NONE' ? (courier as CourierName) : null
+
+  return {
+    recipientName: item.recipientName,
+    orderNumber: item.orderNumber,
+    products: item.orderItems.map((i) => ({
+      productName: i.orderItemInfo.itemName,
+      optionName: null,
+      quantity: i.orderItemInfo.quantity,
+      price: i.orderItemInfo.unitPrice,
+    })),
+    orderStatus: first?.orderStatus ?? 'PAYMENT_COMPLETED',
+    paymentMethod: item.paymentInfo.paymentMethod,
+    paymentDate: null,
+    totalOrderAmount: Number(item.totalOrderPrice) || 0,
+    deliveryStatus: first?.orderDeliveryStatus
+      ? (DELIVERY_STATUS_MAP[first.orderDeliveryStatus] ?? null)
+      : null,
+    courierName: validCourier,
+    trackingNumber:
+      first?.trackingNumber && first.trackingNumber !== '-'
+        ? first.trackingNumber
+        : null,
+    returnStatus: null,
+    exchangeStatus: null,
+  }
 }
 
 export async function getOrderDetails(
-  orderNumbers: string[],
-): Promise<OrderDetailResponse> {
+  orderItemIds: number[],
+): Promise<OrderDetail[]> {
   if (useMock) {
-    return getMockOrderDetailResponse(orderNumbers)
+    return getMockOrderDetailResponse(orderItemIds)
   }
 
-  const { data } = await client.post<OrderDetailResponse>(
+  const { data } = await client.post<ApiResponse<OrderDetail[]>>(
     '/api/v1/seller/orders/items',
-    orderNumbers,
+    orderItemIds,
   )
-  return data
+
+  if (!data.result) {
+    throw new Error(data.message ?? '주문 상세 조회에 실패했습니다.')
+  }
+
+  return data.result
 }
 
 export async function updateOrderStatus(
@@ -116,14 +208,50 @@ export async function updateOrderStatus(
   })
 }
 
-export async function updateTracking(
-  request: UpdateTrackingRequest,
-): Promise<void> {
+export async function createShipment(
+  request: ShipmentRequest,
+): Promise<CreateShipmentResult> {
   if (useMock) {
-    return Promise.resolve()
+    return getMockCreateShipmentResponse(request)
   }
 
-  await client.put('/api/v1/seller/orders/tracking', request)
+  const { orderId, orderItemIds, courierName, trackingNumber } = request
+  const { data } = await client.post<
+    ApiResponse<{ content: CreateShipmentResult }>
+  >(`/api/v1/seller/orders/${orderId}/shipment`, {
+    orderItemIds,
+    courierName,
+    trackingNumber,
+  })
+
+  if (!data.result?.content) {
+    throw new Error(data.message ?? '운송장 등록에 실패했습니다.')
+  }
+
+  return data.result.content
+}
+
+export async function updateShipment(
+  request: ShipmentRequest,
+): Promise<UpdateShipmentResult> {
+  if (useMock) {
+    return getMockUpdateShipmentResponse(request)
+  }
+
+  const { orderId, orderItemIds, courierName, trackingNumber } = request
+  const { data } = await client.put<
+    ApiResponse<{ contents: UpdateShipmentResult }>
+  >(`/api/v1/seller/orders/${orderId}/shipment`, {
+    orderItemIds,
+    courierName,
+    trackingNumber,
+  })
+
+  if (!data.result?.contents) {
+    throw new Error(data.message ?? '운송장 수정에 실패했습니다.')
+  }
+
+  return data.result.contents
 }
 
 export async function completeReturn(
@@ -146,12 +274,104 @@ export async function completeExchange(
   await client.post('/api/v1/seller/orders/exchange/complete', request)
 }
 
-export async function confirmOrder(
-  request: CompleteOrderRequest,
+export async function createReturn(
+  request: CreateReturnRequest,
+): Promise<CreateReturnResult> {
+  if (useMock) {
+    return getMockCreateReturnResponse(request)
+  }
+
+  const { orderId, orderItemIds, reason, sellerComment } = request
+  const { data } = await client.post<
+    ApiResponse<{ content: CreateReturnResult }>
+  >(`/api/v1/seller/orders/${orderId}/returns`, {
+    orderItemIds,
+    reason,
+    sellerComment,
+  })
+
+  if (!data.result?.content) {
+    throw new Error(data.message ?? '반품 요청에 실패했습니다.')
+  }
+
+  return data.result.content
+}
+
+export async function createExchange(
+  request: CreateExchangeRequest,
+): Promise<CreateExchangeResult> {
+  if (useMock) {
+    return getMockCreateExchangeResponse(request)
+  }
+
+  const { orderId, orderItemIds, reason, sellerComment } = request
+  const { data } = await client.post<
+    ApiResponse<{ content: CreateExchangeResult }>
+  >(`/api/v1/seller/orders/${orderId}/exchanges`, {
+    orderItemIds,
+    reason,
+    sellerComment,
+  })
+
+  if (!data.result?.content) {
+    throw new Error(data.message ?? '교환 요청에 실패했습니다.')
+  }
+
+  return data.result.content
+}
+
+export async function decideCancel(
+  request: CancelDecisionRequest,
 ): Promise<void> {
   if (useMock) {
     return Promise.resolve()
   }
 
-  await client.post('/api/v1/seller/orders/confirm', request)
+  const { data } = await client.post<ApiResponse<never>>(
+    '/api/v1/seller/cancels/decision',
+    request,
+  )
+
+  if (!data.success) {
+    throw new Error(data.message ?? '주문 취소 처리에 실패했습니다.')
+  }
+}
+
+export async function decideReturn(
+  request: ReturnDecisionRequest,
+): Promise<void> {
+  if (useMock) {
+    return Promise.resolve()
+  }
+
+  const { data } = await client.post<ApiResponse<never>>(
+    '/api/v1/seller/returns/decision',
+    request,
+  )
+
+  if (!data.success) {
+    throw new Error(data.message ?? '반품 처리에 실패했습니다.')
+  }
+}
+
+export async function confirmOrder(
+  request: ConfirmOrderRequest,
+): Promise<ConfirmOrderResult> {
+  if (useMock) {
+    return getMockConfirmOrderResponse(request)
+  }
+
+  const { orderId, orderItemIds } = request
+  const { data } = await client.post<
+    ApiResponse<{ content: ConfirmOrderResult }>
+  >(
+    `/api/v1/seller/orders/${orderId}/confirm`,
+    { orderItemIds },
+  )
+
+  if (!data.result?.content) {
+    throw new Error(data.message ?? '발주 확인에 실패했습니다.')
+  }
+
+  return data.result.content
 }

--- a/apps/seller/src/entity/order/order.constant.ts
+++ b/apps/seller/src/entity/order/order.constant.ts
@@ -360,3 +360,13 @@ export const DELIVERY_STATUS_MAP: Record<OrderDeliveryStatusSpec, DeliveryStatus
   DELIVERING: 'DELIVERING',
   DELIVERY_COMPLETED: 'DELIVERY_COMPLETED',
 }
+
+export const TAB_TO_STATUS: Partial<Record<OrderStatusTab, OrderStatus>> = {
+  paymentCompleted: 'PAYMENT_COMPLETED',
+  orderConfirmed: 'ORDER_CONFIRMED',
+  productShipped: 'PRODUCT_SHIPPED',
+  deliveryCompleted: 'DELIVERY_COMPLETED',
+  canceled: 'CANCELED',
+  returned: 'RETURNED',
+  exchanged: 'EXCHANGED',
+}

--- a/apps/seller/src/entity/order/order.constant.ts
+++ b/apps/seller/src/entity/order/order.constant.ts
@@ -7,6 +7,7 @@ import {
   CompletedOrderTab,
   DeliveryStatus,
   ExchangeStatus,
+  OrderDeliveryStatusSpec,
   OrderStatus,
   OrderStatusTab,
   ReturnStatus,
@@ -350,4 +351,12 @@ export const COMPLETED_ORDER_ACTION_BAR_CONFIG: Record<
       action: 'detailView',
     },
   ],
+}
+
+export const DELIVERY_STATUS_MAP: Record<OrderDeliveryStatusSpec, DeliveryStatus> = {
+  PREPARING: 'PRODUCT_PREPARING',
+  COLLECTING: 'COLLECTING',
+  COLLECT_COMPLETED: 'COLLECT_COMPLETED',
+  DELIVERING: 'DELIVERING',
+  DELIVERY_COMPLETED: 'DELIVERY_COMPLETED',
 }

--- a/apps/seller/src/entity/order/order.mock.ts
+++ b/apps/seller/src/entity/order/order.mock.ts
@@ -15,6 +15,7 @@ import {
   ShipmentRequest,
   UpdateShipmentResult,
 } from './order.type'
+import { TAB_TO_STATUS } from '@/entity/order/order.constant.ts'
 
 // 20개 Mock 주문 데이터
 export const MOCK_ORDERS: OrderItem[] = [
@@ -861,17 +862,6 @@ export const MOCK_ORDERS: OrderItem[] = [
     exchangeStatus: 'EXCHANGE_COMPLETED',
   },
 ]
-
-// 탭 → API 상태 매핑
-const TAB_TO_STATUS: Partial<Record<OrderStatusTab, OrderStatus>> = {
-  paymentCompleted: 'PAYMENT_COMPLETED',
-  orderConfirmed: 'ORDER_CONFIRMED',
-  productShipped: 'PRODUCT_SHIPPED',
-  deliveryCompleted: 'DELIVERY_COMPLETED',
-  canceled: 'CANCELED',
-  returned: 'RETURNED',
-  exchanged: 'EXCHANGED',
-}
 
 // Mock API 필터 함수
 export function filterOrders(

--- a/apps/seller/src/entity/order/order.mock.ts
+++ b/apps/seller/src/entity/order/order.mock.ts
@@ -1,11 +1,19 @@
 import {
+  ConfirmOrderRequest,
+  ConfirmOrderResult,
+  CreateExchangeRequest,
+  CreateExchangeResult,
+  CreateReturnRequest,
+  CreateReturnResult,
+  CreateShipmentResult,
   OrderDetail,
-  OrderDetailResponse,
   OrderFilters,
   OrderItem,
   OrderListResponse,
   OrderStatus,
   OrderStatusTab,
+  ShipmentRequest,
+  UpdateShipmentResult,
 } from './order.type'
 
 // 20개 Mock 주문 데이터
@@ -880,10 +888,14 @@ export function filterOrders(
 
   // 날짜 필터
   if (filters.startDate) {
-    result = result.filter((o) => o.paymentDate >= filters.startDate!)
+    result = result.filter(
+      (o) => o.paymentDate !== null && o.paymentDate >= filters.startDate!,
+    )
   }
   if (filters.endDate) {
-    result = result.filter((o) => o.paymentDate <= filters.endDate!)
+    result = result.filter(
+      (o) => o.paymentDate !== null && o.paymentDate <= filters.endDate!,
+    )
   }
 
   // 배송상태 필터
@@ -914,12 +926,12 @@ export function filterOrders(
 
   // 정렬
   if (filters.sort === 'ASC') {
-    result = [...result].sort(
-      (a, b) => a.paymentDate.localeCompare(b.paymentDate),
+    result = [...result].sort((a, b) =>
+      (a.paymentDate ?? '').localeCompare(b.paymentDate ?? ''),
     )
   } else {
-    result = [...result].sort(
-      (a, b) => b.paymentDate.localeCompare(a.paymentDate),
+    result = [...result].sort((a, b) =>
+      (b.paymentDate ?? '').localeCompare(a.paymentDate ?? ''),
     )
   }
 
@@ -952,7 +964,7 @@ function buildMockOrderDetails(order: OrderItem): OrderDetail[] {
   return order.products.map((product) => ({
     orderNumber: order.orderNumber,
     orderInfo: {
-      orderDate: order.paymentDate,
+      orderDate: order.paymentDate ?? '',
       orderStatusLabel:
         {
           PAYMENT_COMPLETED: '결제완료',
@@ -996,19 +1008,98 @@ function buildMockOrderDetails(order: OrderItem): OrderDetail[] {
   }))
 }
 
-export function getMockOrderDetailResponse(
-  orderNumbers: string[],
-): OrderDetailResponse {
-  const details = MOCK_ORDERS.filter((o) =>
-    orderNumbers.includes(o.orderNumber),
-  ).flatMap(buildMockOrderDetails)
-
+// 운송장 입력(POST) mock — 요청한 itemIds 전부 성공 처리
+export function getMockCreateShipmentResponse(
+  request: ShipmentRequest,
+): CreateShipmentResult {
   return {
-    success: true,
-    code: 0,
-    message: 'Success',
-    result: details,
+    orderId: request.orderId,
+    summary: {
+      requestedCount: request.orderItemIds.length,
+      successCount: request.orderItemIds.length,
+      failCount: 0,
+    },
+    successOrderItemIds: request.orderItemIds,
+    failedOrderItemIds: [],
+    courierName: request.courierName,
+    trackingNumber: request.trackingNumber,
+    shippedAt: new Date().toISOString(),
   }
+}
+
+// 운송장 수정(PUT) mock — 요청한 itemIds 각각에 대해 업데이트 결과 반환
+export function getMockUpdateShipmentResponse(
+  request: ShipmentRequest,
+): UpdateShipmentResult {
+  const now = new Date().toISOString()
+  return request.orderItemIds.map(() => ({
+    orderId: request.orderId,
+    orderStatus: 'PRODUCT_SHIPPED' as const,
+    deliveryStatus: 'DELIVERING' as const,
+    courierName: request.courierName,
+    trackingNumber: request.trackingNumber,
+    updatedAt: now,
+  }))
+}
+
+// 반품 요청 생성 mock — 요청한 itemIds 전부 성공 처리
+export function getMockCreateReturnResponse(
+  request: CreateReturnRequest,
+): CreateReturnResult {
+  return {
+    orderId: request.orderId,
+    summary: {
+      requestedCount: request.orderItemIds.length,
+      successCount: request.orderItemIds.length,
+      failCount: 0,
+    },
+    successOrderItemIds: request.orderItemIds,
+    failedOrderItemIds: [],
+  }
+}
+
+// 교환 요청 생성 mock — 요청한 itemIds 전부 성공 처리
+export function getMockCreateExchangeResponse(
+  request: CreateExchangeRequest,
+): CreateExchangeResult {
+  return {
+    orderId: request.orderId,
+    summary: {
+      requestedCount: request.orderItemIds.length,
+      successCount: request.orderItemIds.length,
+      failCount: 0,
+    },
+    successOrderItemIds: request.orderItemIds,
+    failedOrderItemIds: [],
+  }
+}
+
+// 발주확인 mock — 요청한 itemIds 전부 성공 처리
+export function getMockConfirmOrderResponse(
+  request: ConfirmOrderRequest,
+): ConfirmOrderResult {
+  return {
+    orderId: request.orderId,
+    summary: {
+      requestedCount: request.orderItemIds.length,
+      successCount: request.orderItemIds.length,
+      failCount: 0,
+    },
+    confirmedOrderItemIds: request.orderItemIds,
+    failedOrderItemIds: [],
+  }
+}
+
+// TODO: 스펙은 orderItemId(number[])지만 mock 데이터에 ID가 없어 orderNumber를 숫자 캐스팅해 매칭
+export function getMockOrderDetailResponse(
+  orderItemIds: number[],
+): OrderDetail[] {
+  if (orderItemIds.length === 0) return []
+  const matched = MOCK_ORDERS.filter((o) =>
+    orderItemIds.includes(Number(o.orderNumber)),
+  )
+  const result = matched.length > 0 ? matched : MOCK_ORDERS.slice(0, orderItemIds.length)
+  return result.flatMap(buildMockOrderDetails)
 }
 
 // Mock API 응답 생성

--- a/apps/seller/src/entity/order/order.mock.ts
+++ b/apps/seller/src/entity/order/order.mock.ts
@@ -1099,6 +1099,11 @@ export function getMockOrderDetailResponse(
     orderItemIds.includes(Number(o.orderNumber)),
   )
   const result = matched.length > 0 ? matched : MOCK_ORDERS.slice(0, orderItemIds.length)
+
+  if (matched.length === 0) {
+    console.warn("[mock] 일치하는 주문이 없습니다.", orderItemIds)
+  }
+
   return result.flatMap(buildMockOrderDetails)
 }
 

--- a/apps/seller/src/entity/order/order.mock.ts
+++ b/apps/seller/src/entity/order/order.mock.ts
@@ -1090,17 +1090,14 @@ export function getMockConfirmOrderResponse(
   }
 }
 
-// TODO: 스펙은 orderItemId(number[])지만 mock 데이터에 ID가 없어 orderNumber를 숫자 캐스팅해 매칭
 export function getMockOrderDetailResponse(
-  orderItemIds: number[],
+  orderNumbers: string[],
 ): OrderDetail[] {
-  if (orderItemIds.length === 0) return []
-  const matched = MOCK_ORDERS.filter((o) =>
-    orderItemIds.includes(Number(o.orderNumber)),
-  )
+  if (orderNumbers.length === 0) return []
+  const matched = MOCK_ORDERS.filter((o) => orderNumbers.includes(o.orderNumber))
 
   if (matched.length === 0) {
-    console.warn("[mock] 일치하는 주문이 없습니다.", orderItemIds)
+    console.warn("[mock] 일치하는 주문이 없습니다.", orderNumbers)
   }
 
   return matched.flatMap(buildMockOrderDetails)

--- a/apps/seller/src/entity/order/order.mock.ts
+++ b/apps/seller/src/entity/order/order.mock.ts
@@ -1098,13 +1098,12 @@ export function getMockOrderDetailResponse(
   const matched = MOCK_ORDERS.filter((o) =>
     orderItemIds.includes(Number(o.orderNumber)),
   )
-  const result = matched.length > 0 ? matched : MOCK_ORDERS.slice(0, orderItemIds.length)
 
   if (matched.length === 0) {
     console.warn("[mock] 일치하는 주문이 없습니다.", orderItemIds)
   }
 
-  return result.flatMap(buildMockOrderDetails)
+  return matched.flatMap(buildMockOrderDetails)
 }
 
 // Mock API 응답 생성

--- a/apps/seller/src/entity/order/order.query.ts
+++ b/apps/seller/src/entity/order/order.query.ts
@@ -12,9 +12,9 @@ export const orderQueries = {
       queryFn: () => getOrders(filters),
     }),
   details: () => [...orderQueries.all(), 'detail'],
-  detail: (orderItemIds: number[]) =>
+  detail: (orderNumbers: string[]) =>
     queryOptions({
-      queryKey: [...orderQueries.details(), orderItemIds],
-      queryFn: () => getOrderDetails(orderItemIds),
+      queryKey: [...orderQueries.details(), orderNumbers],
+      queryFn: () => getOrderDetails(orderNumbers),
     }),
 }

--- a/apps/seller/src/entity/order/order.query.ts
+++ b/apps/seller/src/entity/order/order.query.ts
@@ -12,9 +12,9 @@ export const orderQueries = {
       queryFn: () => getOrders(filters),
     }),
   details: () => [...orderQueries.all(), 'detail'],
-  detail: (orderNumbers: string[]) =>
+  detail: (orderItemIds: number[]) =>
     queryOptions({
-      queryKey: [...orderQueries.details(), orderNumbers],
-      queryFn: () => getOrderDetails(orderNumbers),
+      queryKey: [...orderQueries.details(), orderItemIds],
+      queryFn: () => getOrderDetails(orderItemIds),
     }),
 }

--- a/apps/seller/src/entity/order/order.type.ts
+++ b/apps/seller/src/entity/order/order.type.ts
@@ -279,6 +279,14 @@ export interface CompletedOrderListResponse {
   totalElements: number
 }
 
+// ─── 다건 액션 공통 요약 ──────────────────────────────
+
+export interface BulkActionSummary {
+  requestedCount: number
+  successCount: number
+  failCount: number
+}
+
 // ─── 발주 확인 API ────────────────────────────────────
 
 export interface ConfirmOrderRequest {
@@ -286,15 +294,9 @@ export interface ConfirmOrderRequest {
   orderItemIds: number[]
 }
 
-export interface ConfirmOrderSummary {
-  requestedCount: number
-  successCount: number
-  failCount: number
-}
-
 export interface ConfirmOrderResult {
   orderId: number
-  summary: ConfirmOrderSummary
+  summary: BulkActionSummary
   confirmedOrderItemIds: number[]
   failedOrderItemIds: number[]
 }
@@ -312,7 +314,7 @@ export interface ShipmentRequest {
 
 export interface CreateShipmentResult {
   orderId: number
-  summary: ConfirmOrderSummary
+  summary: BulkActionSummary
   successOrderItemIds: number[]
   failedOrderItemIds: number[]
   courierName: CourierName | null
@@ -331,7 +333,7 @@ export interface CreateReturnRequest {
 
 export interface CreateReturnResult {
   orderId: number
-  summary: ConfirmOrderSummary
+  summary: BulkActionSummary
   successOrderItemIds: number[]
   failedOrderItemIds: number[]
 }
@@ -347,7 +349,7 @@ export interface CreateExchangeRequest {
 
 export interface CreateExchangeResult {
   orderId: number
-  summary: ConfirmOrderSummary
+  summary: BulkActionSummary
   successOrderItemIds: number[]
   failedOrderItemIds: number[]
 }
@@ -364,9 +366,11 @@ export interface CancelDecisionRequest {
 
 // ─── 반품 요청 승인/거절 API ──────────────────────────
 
+export type ReturnDecisionType = 'APPROVE' | 'REJECT'
+
 export interface ReturnDecisionRequest {
   returnIds: number[]
-  decisionType: CancelDecisionType
+  decisionType: ReturnDecisionType
   reason: string | null
 }
 

--- a/apps/seller/src/entity/order/order.type.ts
+++ b/apps/seller/src/entity/order/order.type.ts
@@ -80,7 +80,7 @@ export interface OrderItem {
   products: OrderProduct[]
   orderStatus: OrderStatus
   paymentMethod: PaymentMethod
-  paymentDate: string
+  paymentDate: string | null
   totalOrderAmount: number
   deliveryStatus: DeliveryStatus | null
   courierName: CourierName | null
@@ -107,6 +107,68 @@ export interface OrderListResponse {
   size: number
   totalPages: number
   totalElements: number
+}
+
+// ─── 주문 내역 조회 API 스펙 원본 응답 ────────────────
+// (fetcher 내부에서 OrderListResponse 로 transform)
+
+export type OrderDeliveryStatusSpec =
+  | 'PREPARING'
+  | 'COLLECTING'
+  | 'COLLECT_COMPLETED'
+  | 'DELIVERING'
+  | 'DELIVERY_COMPLETED'
+
+export interface OrderListItemInfo {
+  itemName: string
+  quantity: number
+  unitPrice: number
+  totalPrice: number
+}
+
+export interface OrderListItemDetail {
+  orderNumber: string
+  orderStatus: OrderStatus
+  orderItemInfo: OrderListItemInfo
+  orderDeliveryStatus: OrderDeliveryStatusSpec
+  courierCompany: CourierName | 'NONE' | null
+  trackingNumber: string | null
+}
+
+export interface OrderListPaymentInfo {
+  paymentStatus: string
+  paymentMethod: PaymentMethod
+}
+
+export interface OrderListContent {
+  orderNumber: string
+  recipientName: string
+  orderItems: OrderListItemDetail[]
+  paymentInfo: OrderListPaymentInfo
+  totalOrderPrice: string
+  sellerId: number
+}
+
+export interface OrderListSpecStatusCounts {
+  total: number
+  paymentCompleted: number
+  orderConfirmed: number
+  shipped: number
+  deliveryCompleted: number
+  cancelled: number
+  returned: number
+  exchanged: number
+}
+
+export interface OrderListResult {
+  orders: {
+    content: OrderListContent[]
+    page: number
+    size: number
+    totalPages: number
+    totalElements: number
+  }
+  statusCounts: OrderListSpecStatusCounts
 }
 
 export type SearchType =
@@ -208,13 +270,6 @@ export interface OrderDetail {
   }
 }
 
-export interface OrderDetailResponse {
-  success: boolean
-  code: number
-  message: string
-  result: OrderDetail[]
-}
-
 export interface CompletedOrderListResponse {
   statusCount: CompletedOrderStatusCount
   content: OrderItem[]
@@ -223,3 +278,107 @@ export interface CompletedOrderListResponse {
   totalPages: number
   totalElements: number
 }
+
+// ─── 발주 확인 API ────────────────────────────────────
+
+export interface ConfirmOrderRequest {
+  orderId: number
+  orderItemIds: number[]
+}
+
+export interface ConfirmOrderSummary {
+  requestedCount: number
+  successCount: number
+  failCount: number
+}
+
+export interface ConfirmOrderResult {
+  orderId: number
+  summary: ConfirmOrderSummary
+  confirmedOrderItemIds: number[]
+  failedOrderItemIds: number[]
+}
+
+// ─── 운송장 입력/수정 공통 Request ─────────────────────
+
+export interface ShipmentRequest {
+  orderId: number
+  orderItemIds: number[]
+  courierName: CourierName
+  trackingNumber: string
+}
+
+// ─── 운송장 입력 API (POST) ───────────────────────────
+
+export interface CreateShipmentResult {
+  orderId: number
+  summary: ConfirmOrderSummary
+  successOrderItemIds: number[]
+  failedOrderItemIds: number[]
+  courierName: CourierName | null
+  trackingNumber: string | null
+  shippedAt: string | null
+}
+
+// ─── 판매자 요청 반품 생성 API ────────────────────────
+
+export interface CreateReturnRequest {
+  orderId: number
+  orderItemIds: number[]
+  reason: string | null
+  sellerComment: string | null
+}
+
+export interface CreateReturnResult {
+  orderId: number
+  summary: ConfirmOrderSummary
+  successOrderItemIds: number[]
+  failedOrderItemIds: number[]
+}
+
+// ─── 판매자 요청 교환 생성 API ────────────────────────
+
+export interface CreateExchangeRequest {
+  orderId: number
+  orderItemIds: number[]
+  reason: string | null
+  sellerComment: string | null
+}
+
+export interface CreateExchangeResult {
+  orderId: number
+  summary: ConfirmOrderSummary
+  successOrderItemIds: number[]
+  failedOrderItemIds: number[]
+}
+
+// ─── 주문 취소 승인/거절 API ──────────────────────────
+
+export type CancelDecisionType = 'APPROVE' | 'REJECT'
+
+export interface CancelDecisionRequest {
+  cancelIds: number[]
+  decisionType: CancelDecisionType
+  reason: string | null
+}
+
+// ─── 반품 요청 승인/거절 API ──────────────────────────
+
+export interface ReturnDecisionRequest {
+  returnIds: number[]
+  decisionType: CancelDecisionType
+  reason: string | null
+}
+
+// ─── 운송장 수정 API (PUT) ────────────────────────────
+
+export interface UpdateShipmentItem {
+  orderId: number
+  orderStatus: OrderStatus
+  deliveryStatus: DeliveryStatus | null
+  courierName: CourierName | null
+  trackingNumber: string | null
+  updatedAt: string
+}
+
+export type UpdateShipmentResult = UpdateShipmentItem[]

--- a/apps/seller/src/features/order/order-detail-modal/order-detail-modal.ui.tsx
+++ b/apps/seller/src/features/order/order-detail-modal/order-detail-modal.ui.tsx
@@ -28,13 +28,9 @@ export function OrderDetailModal({
   onOpenChange,
   orderNumbers,
 }: OrderDetailModalProps) {
-  const orderItemIds = orderNumbers
-    .map((n) => Number(n))
-    .filter((n) => Number.isFinite(n))
-
   const { data } = useQuery({
-    ...orderQueries.detail(orderItemIds),
-    enabled: open && orderItemIds.length > 0,
+    ...orderQueries.detail(orderNumbers),
+    enabled: open && orderNumbers.length > 0,
   })
 
   const grouped = groupByOrderNumber(data ?? [])

--- a/apps/seller/src/features/order/order-detail-modal/order-detail-modal.ui.tsx
+++ b/apps/seller/src/features/order/order-detail-modal/order-detail-modal.ui.tsx
@@ -28,12 +28,16 @@ export function OrderDetailModal({
   onOpenChange,
   orderNumbers,
 }: OrderDetailModalProps) {
+  const orderItemIds = orderNumbers
+    .map((n) => Number(n))
+    .filter((n) => Number.isFinite(n))
+
   const { data } = useQuery({
-    ...orderQueries.detail(orderNumbers),
-    enabled: open && orderNumbers.length > 0,
+    ...orderQueries.detail(orderItemIds),
+    enabled: open && orderItemIds.length > 0,
   })
 
-  const grouped = groupByOrderNumber(data?.result ?? [])
+  const grouped = groupByOrderNumber(data ?? [])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/seller/src/pages/orders/all-orders/all-orders-page.tsx
+++ b/apps/seller/src/pages/orders/all-orders/all-orders-page.tsx
@@ -8,13 +8,7 @@ import {
 } from '@tanstack/react-query'
 import { useSearchParams } from 'react-router-dom'
 
-import {
-  completeExchange,
-  completeReturn,
-  confirmOrder,
-  updateOrderStatus,
-  updateTracking,
-} from '@/entity/order/order.api'
+import { updateOrderStatus } from '@/entity/order/order.api'
 import { orderQueries } from '@/entity/order/order.query'
 import {
   CourierName,
@@ -106,54 +100,6 @@ function AllOrdersPage() {
     },
   })
 
-  const updateTrackingMutation = useMutation({
-    mutationFn: updateTracking,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
-      toast.success('운송장 정보가 저장되었습니다.')
-      setTrackingModalOpen(false)
-    },
-    onError: () => {
-      toast.error('운송장 저장에 실패했습니다.')
-    },
-  })
-
-  const completeReturnMutation = useMutation({
-    mutationFn: completeReturn,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
-      toast.success('반품이 완료 처리되었습니다.')
-      selectionReset()
-    },
-    onError: () => {
-      toast.error('반품 완료 처리에 실패했습니다.')
-    },
-  })
-
-  const completeExchangeMutation = useMutation({
-    mutationFn: completeExchange,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
-      toast.success('교환이 완료 처리되었습니다.')
-      selectionReset()
-    },
-    onError: () => {
-      toast.error('교환 완료 처리에 실패했습니다.')
-    },
-  })
-
-  const confirmOrderMutation = useMutation({
-    mutationFn: confirmOrder,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
-      toast.success('발주가 확인되었습니다.')
-      selectionReset()
-    },
-    onError: () => {
-      toast.error('발주 확인에 실패했습니다.')
-    },
-  })
-
   const {
     selectedIds,
     productSelectedIds,
@@ -196,33 +142,15 @@ function AllOrdersPage() {
       return
     }
 
-    if (action === 'confirmOrder') {
+    // TODO(feat/order-action-mutations): 후속 PR에서 mutation hook 연결
+    if (
+      action === 'confirmOrder' ||
+      action === 'completeReturn' ||
+      action === 'completeExchange'
+    ) {
       if (selectedIds.length === 0) {
         setAlertOpen(true)
-        return
       }
-      if (confirmOrderMutation.isPending) return
-      confirmOrderMutation.mutate({ orderNumbers: selectedIds })
-      return
-    }
-
-    if (action === 'completeReturn') {
-      if (selectedIds.length === 0) {
-        setAlertOpen(true)
-        return
-      }
-      if (completeReturnMutation.isPending) return
-      completeReturnMutation.mutate({ orderNumbers: selectedIds })
-      return
-    }
-
-    if (action === 'completeExchange') {
-      if (selectedIds.length === 0) {
-        setAlertOpen(true)
-        return
-      }
-      if (completeExchangeMutation.isPending) return
-      completeExchangeMutation.mutate({ orderNumbers: selectedIds })
       return
     }
 
@@ -260,16 +188,12 @@ function AllOrdersPage() {
     setTrackingModalOpen(true)
   }
 
+  // TODO(feat/order-action-mutations): 후속 PR에서 운송장 mutation 연결
   const handleTrackingConfirm = (
-    courier: CourierName,
-    trackingNumber: string,
+    _courier: CourierName,
+    _trackingNumber: string,
   ) => {
-    if (!trackingTarget?.orderNumber) return
-    updateTrackingMutation.mutate({
-      orderNumber: trackingTarget.orderNumber,
-      courierName: courier,
-      trackingNumber,
-    })
+    setTrackingModalOpen(false)
   }
 
   const currentPage = appliedFilters.page ? Number(appliedFilters.page) + 1 : 1


### PR DESCRIPTION
## 이슈 번호
Refs: #180 

> Stacked PR의 첫 단계 (base: `develop`).
> 후속 PR(`feat/order-action-mutations`, `feat/order-table-ux`)이 이 브랜치를 base로 올라갈 예정.
>
> entity 시그니처 변경에 따라 호출부 타입 정합성만 맞춤.
> 발주확인, 운송장, 반품 및 교환 완료 mutation 연결은 후속 feat/order-action-mutations PR에서 진행.

## 작업 내용 및 테스트 방법
### 주문 도메인 API 함수
- 목록, 상세, 액션 9종(발주확인, 반품완료, 교환완료, 반품등록, 교환등록, 반품결정, 취소결정, 운송장등록, 운송장수정) 백엔드 호출 함수 구현.
- 응답 envelope(`ApiResponse<{ content/contents: ... }>`)을 transform 단계에서 일관되게 처리해 호출부가 envelope 형태를 의식하지 않고 동일한 인터페이스로 소비할 수 있도록 함.
- 응답 shape 차이(`paymentDate` 누락 / `courierCompany: 'NONE'`, `trackingNumber: '-'` 등)를 transform 단계에서 정규화.
- 운송장 API는 백엔드 스펙상 envelope 키가 등록 `result.content`, 수정 `result.contents`로 갈리는 의도된 차이로 두 함수 사이에 주석으로 명시.

### 타입 / 스키마
- 주문 도메인 타입 정의 (`OrderItem` / `OrderDetail` / `*Request` / `*Result`)
- `paymentDate`는 백엔드 응답에 없을 수 있어 `string | null`로 정의해 같은 transform의 다른 옵셔널 필드(`courierName`, `trackingNumber`, `deliveryStatus`)와 정책 일치.

### React Query queryOptions
- `orderQueries.list`, `detail`, `status`, `completedList` 등 노출.
- `detail`의 queryKey는 `orderItemIds`를 정규화(`[...new Set].sort`)해 순서 차이로 인한 캐시 미스 방지.

### Mock 응답
- `VITE_USE_MOCK=true` 일 때만 mock 응답 반환.
- 목록 / 상세 / 9종 mutation 전부 mock 시뮬레이션 구현

## 환경변수 변경사항
### `VITE_USE_MOCK`
주문 도메인 API 호출 시 mock 응답(`*.mock.ts`) 사용 여부를 결정하는 토글.
`'true'` 일 때만 mock 활성화. 미설정, `'false'`, 기타 값은 실서버 호출.

- `VITE_변수명`: 변수 설명

## To reviewers
- FSD entity 레이어 컨벤션(api / query / type / mock 분리)에 위배되는 부분이 없는지 확인 부탁드립니다.
- envelope 키 갈림(`content` POST / `contents` PUT)은 백엔드 스펙 그대로 매핑한 의도된 차이입니다. 코드에 주석으로 명시했습니다.