### PR TITLE
✨Feat: 주문 액션 Mutation·플로우 훅 및 페이지 연결

### DIFF
--- a/apps/seller/src/entity/order/order.constant.ts
+++ b/apps/seller/src/entity/order/order.constant.ts
@@ -361,6 +361,9 @@ export const DELIVERY_STATUS_MAP: Record<OrderDeliveryStatusSpec, DeliveryStatus
   DELIVERY_COMPLETED: 'DELIVERY_COMPLETED',
 }
 
+// 다건 mutation을 chunk 단위로 끊어 호출하기 위한 동시성 상한.
+export const MUTATION_BATCH_SIZE = 10
+
 export const TAB_TO_STATUS: Partial<Record<OrderStatusTab, OrderStatus>> = {
   paymentCompleted: 'PAYMENT_COMPLETED',
   orderConfirmed: 'ORDER_CONFIRMED',

--- a/apps/seller/src/entity/order/order.type.ts
+++ b/apps/seller/src/entity/order/order.type.ts
@@ -67,6 +67,25 @@ export type CourierName =
   | 'GSPostbox택배'
   | '기타'
 
+export type OrderAction =
+  | 'detailView'
+  | 'confirmOrder'
+  | 'cancelOrder'
+  | 'requestReturn'
+  | 'requestExchange'
+  | 'approveCancellation'
+  | 'rejectCancellation'
+  | 'approveReturn'
+  | 'rejectReturn'
+  | 'completeReturn'
+  | 'turnDownReturn'
+  | 'holdReturn'
+  | 'approveExchange'
+  | 'rejectExchange'
+  | 'completeExchange'
+  | 'turnDownExchange'
+  | 'holdExchange'
+
 export interface OrderProduct {
   productName: string
   optionName: string | null
@@ -196,7 +215,7 @@ type SingleButton = {
   type: 'single'
   label: string
   variant: 'primary-outlined' | 'secondary-outlined'
-  action: string // 이벤트 핸들러 key
+  action: OrderAction // 이벤트 핸들러 key
 }
 
 // 버튼 그룹 (취소/반품/교환 탭에서 사용)
@@ -204,7 +223,7 @@ type GroupButton = {
   type: 'group'
   items: Array<{
     label: string
-    action: string
+    action: OrderAction
   }>
 }
 

--- a/apps/seller/src/features/order/completed-order-action-bar/completed-order-action-bar.ui.tsx
+++ b/apps/seller/src/features/order/completed-order-action-bar/completed-order-action-bar.ui.tsx
@@ -1,11 +1,15 @@
 import { Button, Pagination } from '@dessert/ui'
 
 import { COMPLETED_ORDER_ACTION_BAR_CONFIG } from '@/entity/order/order.constant'
-import { ActionButton, CompletedOrderTab } from '@/entity/order/order.type'
+import {
+  ActionButton,
+  CompletedOrderTab,
+  OrderAction,
+} from '@/entity/order/order.type'
 
 interface CompletedOrderActionBarProps {
   tab: CompletedOrderTab
-  onAction: (action: string) => void
+  onAction: (action: OrderAction) => void
   selectedCount: number
   totalCount: number
   currentPage: number
@@ -56,7 +60,7 @@ export function CompletedOrderActionBar({
 
 interface CompletedOrderActionButtonProps {
   buttons: ActionButton[]
-  onAction: (action: string) => void
+  onAction: (action: OrderAction) => void
 }
 
 function CompletedOrderActionButton({

--- a/apps/seller/src/features/order/order-action-bar/complete-exchange.mutation.ts
+++ b/apps/seller/src/features/order/order-action-bar/complete-exchange.mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { completeExchange } from '@/entity/order/order.api'
+import { orderQueries } from '@/entity/order/order.query'
+
+export const useCompleteExchangeMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: completeExchange,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    },
+  })
+}

--- a/apps/seller/src/features/order/order-action-bar/complete-return.mutation.ts
+++ b/apps/seller/src/features/order/order-action-bar/complete-return.mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { completeReturn } from '@/entity/order/order.api'
+import { orderQueries } from '@/entity/order/order.query'
+
+export const useCompleteReturnMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: completeReturn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    },
+  })
+}

--- a/apps/seller/src/features/order/order-action-bar/confirm-order.mutation.ts
+++ b/apps/seller/src/features/order/order-action-bar/confirm-order.mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { confirmOrder } from '@/entity/order/order.api'
+import { orderQueries } from '@/entity/order/order.query'
+
+export const useConfirmOrderMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: confirmOrder,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    },
+  })
+}

--- a/apps/seller/src/features/order/order-action-bar/confirm-order.mutation.ts
+++ b/apps/seller/src/features/order/order-action-bar/confirm-order.mutation.ts
@@ -1,15 +1,10 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 
 import { confirmOrder } from '@/entity/order/order.api'
-import { orderQueries } from '@/entity/order/order.query'
 
-export const useConfirmOrderMutation = () => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
+// 다건 병렬 호출 사용처에서 onSuccess invalidate 폭주를 피하기 위해
+// 무효화 책임은 호출부(useOrderActionBar)가 batch 종료 시 1회만 수행한다.
+export const useConfirmOrderMutation = () =>
+  useMutation({
     mutationFn: confirmOrder,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
-    },
   })
-}

--- a/apps/seller/src/features/order/order-action-bar/index.ts
+++ b/apps/seller/src/features/order/order-action-bar/index.ts
@@ -1,1 +1,2 @@
 export { OrderActionBar } from './order-action-bar.ui'
+export { useOrderActionBar } from './use-order-action-bar.hook'

--- a/apps/seller/src/features/order/order-action-bar/order-action-bar.ui.tsx
+++ b/apps/seller/src/features/order/order-action-bar/order-action-bar.ui.tsx
@@ -1,11 +1,15 @@
 import { Button, Pagination } from '@dessert/ui'
 
 import { ORDER_ACTION_BAR_CONFIG } from '@/entity/order/order.constant'
-import { ActionButton, OrderStatusTab } from '@/entity/order/order.type'
+import {
+  ActionButton,
+  OrderAction,
+  OrderStatusTab,
+} from '@/entity/order/order.type'
 
 interface OrderActionBarProps {
   tab: OrderStatusTab
-  onAction: (action: string) => void
+  onAction: (action: OrderAction) => void
   selectedCount: number // 선택된 주문 수
   totalCount: number // 전체 주문 수
   currentPage: number
@@ -56,7 +60,7 @@ export function OrderActionBar({
 
 interface OrderActionButtonProps {
   buttons: ActionButton[]
-  onAction: (action: string) => void
+  onAction: (action: OrderAction) => void
 }
 
 function OrderActionButton({ buttons, onAction }: OrderActionButtonProps) {

--- a/apps/seller/src/features/order/order-action-bar/order-action-bar.ui.tsx
+++ b/apps/seller/src/features/order/order-action-bar/order-action-bar.ui.tsx
@@ -75,20 +75,20 @@ function OrderActionButton({ buttons, onAction }: OrderActionButtonProps) {
           )
         }
 
-        // todo: type === 'group' -> ButtonGroup 공통 컴포넌트로 추출 예정
         return (
           <div
             key={index}
             className="flex overflow-clip rounded-6 border border-gray-200"
           >
             {button.items.map((item) => (
-              <button
+              <Button
                 key={item.action}
-                className="cursor-pointer border-r border-gray-200 px-10 py-6 typo-body-12-m text-gray-800 last:border-r-0"
+                title={item.label}
+                variant="secondary-outlined"
+                size="sm"
                 onClick={() => onAction(item.action)}
-              >
-                {item.label}
-              </button>
+                className="h-auto min-w-0 rounded-none border-0 border-r border-gray-200 px-10 py-6 text-gray-800 last:border-r-0"
+              />
             ))}
           </div>
         )

--- a/apps/seller/src/features/order/order-action-bar/use-order-action-bar.hook.ts
+++ b/apps/seller/src/features/order/order-action-bar/use-order-action-bar.hook.ts
@@ -37,6 +37,12 @@ export function useOrderActionBar({
     const targetOrderIds = selectedIds
       .map((orderNumber) => Number(orderNumber))
       .filter((id) => Number.isFinite(id))
+    const invalidCount = selectedIds.length - targetOrderIds.length
+
+    if (targetOrderIds.length === 0) {
+      toast.error('유효한 주문이 없습니다.')
+      return
+    }
 
     const results = await Promise.allSettled(
       targetOrderIds.map((id) =>
@@ -47,7 +53,7 @@ export function useOrderActionBar({
     const successCount = results.filter(
       (r) => r.status === 'fulfilled' && r.value.summary.successCount > 0,
     ).length
-    const failCount = results.length - successCount
+    const failCount = results.length - successCount + invalidCount
 
     if (successCount > 0) {
       onClearSelection()

--- a/apps/seller/src/features/order/order-action-bar/use-order-action-bar.hook.ts
+++ b/apps/seller/src/features/order/order-action-bar/use-order-action-bar.hook.ts
@@ -1,0 +1,118 @@
+import { toast } from '@dessert/ui'
+
+import { useCompleteExchangeMutation } from './complete-exchange.mutation'
+import { useCompleteReturnMutation } from './complete-return.mutation'
+import { useConfirmOrderMutation } from './confirm-order.mutation'
+
+interface UseOrderActionBarParams {
+  selectedIds: string[]
+  onClearSelection: () => void
+  onShowDetail: () => void
+  onSelectionEmpty: () => void
+  onUnhandled: (action: string) => void
+}
+
+export function useOrderActionBar({
+  selectedIds,
+  onClearSelection,
+  onShowDetail,
+  onSelectionEmpty,
+  onUnhandled,
+}: UseOrderActionBarParams) {
+  const confirmOrderMutation = useConfirmOrderMutation()
+  const completeReturnMutation = useCompleteReturnMutation()
+  const completeExchangeMutation = useCompleteExchangeMutation()
+
+  const isPending =
+    confirmOrderMutation.isPending ||
+    completeReturnMutation.isPending ||
+    completeExchangeMutation.isPending
+
+  const submitConfirmOrders = async () => {
+    const targetOrderIds = selectedIds
+      .map((orderNumber) => Number(orderNumber))
+      .filter((id) => Number.isFinite(id))
+
+    const results = await Promise.allSettled(
+      targetOrderIds.map((id) =>
+        confirmOrderMutation.mutateAsync({ orderId: id, orderItemIds: [id] }),
+      ),
+    )
+
+    const successCount = results.filter(
+      (r) => r.status === 'fulfilled' && r.value.summary.successCount > 0,
+    ).length
+    const failCount = results.length - successCount
+
+    if (successCount > 0) onClearSelection()
+
+    if (failCount === 0) {
+      toast.success(`${successCount}건 발주 확인 완료`)
+    } else if (successCount > 0) {
+      toast.success(`${successCount}건 성공, ${failCount}건 실패`)
+    } else {
+      toast.error('발주 확인에 실패했습니다.')
+    }
+  }
+
+  const bulkCompleteActions: Record<
+    string,
+    {
+      mutation: typeof completeReturnMutation
+      successMessage: string
+      errorMessage: string
+    }
+  > = {
+    completeReturn: {
+      mutation: completeReturnMutation,
+      successMessage: '반품이 완료 처리되었습니다.',
+      errorMessage: '반품 완료 처리에 실패했습니다.',
+    },
+    completeExchange: {
+      mutation: completeExchangeMutation,
+      successMessage: '교환이 완료 처리되었습니다.',
+      errorMessage: '교환 완료 처리에 실패했습니다.',
+    },
+  }
+
+  const handleAction = (action: string) => {
+    if (selectedIds.length === 0) {
+      onSelectionEmpty()
+      return
+    }
+
+    if (action === 'detailView') {
+      onShowDetail()
+      return
+    }
+
+    if (action === 'confirmOrder') {
+      if (confirmOrderMutation.isPending) return
+      void submitConfirmOrders()
+      return
+    }
+
+    const meta = bulkCompleteActions[action]
+    if (meta) {
+      if (meta.mutation.isPending) return
+      meta.mutation.mutate(
+        { orderNumbers: selectedIds },
+        {
+          onSuccess: () => {
+            toast.success(meta.successMessage)
+            onClearSelection()
+          },
+          onError: () => toast.error(meta.errorMessage),
+        },
+      )
+      return
+    }
+
+    onUnhandled(action)
+  }
+
+  return {
+    handleAction,
+    isPending,
+  }
+}

--- a/apps/seller/src/features/order/order-action-bar/use-order-action-bar.hook.ts
+++ b/apps/seller/src/features/order/order-action-bar/use-order-action-bar.hook.ts
@@ -1,9 +1,12 @@
+import { useQueryClient } from '@tanstack/react-query'
+
 import { toast } from '@dessert/ui'
 
 import { useCompleteExchangeMutation } from './complete-exchange.mutation'
 import { useCompleteReturnMutation } from './complete-return.mutation'
 import { useConfirmOrderMutation } from './confirm-order.mutation'
 import { OrderAction } from '@/entity/order'
+import { orderQueries } from '@/entity/order/order.query'
 
 interface UseOrderActionBarParams {
   selectedIds: string[]
@@ -20,6 +23,7 @@ export function useOrderActionBar({
   onSelectionEmpty,
   onUnhandled,
 }: UseOrderActionBarParams) {
+  const queryClient = useQueryClient()
   const confirmOrderMutation = useConfirmOrderMutation()
   const completeReturnMutation = useCompleteReturnMutation()
   const completeExchangeMutation = useCompleteExchangeMutation()
@@ -45,7 +49,10 @@ export function useOrderActionBar({
     ).length
     const failCount = results.length - successCount
 
-    if (successCount > 0) onClearSelection()
+    if (successCount > 0) {
+      onClearSelection()
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    }
 
     if (failCount === 0) {
       toast.success(`${successCount}건 발주 확인 완료`)

--- a/apps/seller/src/features/order/order-action-bar/use-order-action-bar.hook.ts
+++ b/apps/seller/src/features/order/order-action-bar/use-order-action-bar.hook.ts
@@ -5,8 +5,9 @@ import { toast } from '@dessert/ui'
 import { useCompleteExchangeMutation } from './complete-exchange.mutation'
 import { useCompleteReturnMutation } from './complete-return.mutation'
 import { useConfirmOrderMutation } from './confirm-order.mutation'
-import { OrderAction } from '@/entity/order'
+import { MUTATION_BATCH_SIZE, OrderAction } from '@/entity/order'
 import { orderQueries } from '@/entity/order/order.query'
+import { settledInBatches } from '@/shared/utils/promise'
 
 interface UseOrderActionBarParams {
   selectedIds: string[]
@@ -44,10 +45,11 @@ export function useOrderActionBar({
       return
     }
 
-    const results = await Promise.allSettled(
-      targetOrderIds.map((id) =>
+    const results = await settledInBatches(
+      targetOrderIds,
+      MUTATION_BATCH_SIZE,
+      (id) =>
         confirmOrderMutation.mutateAsync({ orderId: id, orderItemIds: [id] }),
-      ),
     )
 
     const successCount = results.filter(

--- a/apps/seller/src/features/order/order-action-bar/use-order-action-bar.hook.ts
+++ b/apps/seller/src/features/order/order-action-bar/use-order-action-bar.hook.ts
@@ -3,13 +3,14 @@ import { toast } from '@dessert/ui'
 import { useCompleteExchangeMutation } from './complete-exchange.mutation'
 import { useCompleteReturnMutation } from './complete-return.mutation'
 import { useConfirmOrderMutation } from './confirm-order.mutation'
+import { OrderAction } from '@/entity/order'
 
 interface UseOrderActionBarParams {
   selectedIds: string[]
   onClearSelection: () => void
   onShowDetail: () => void
   onSelectionEmpty: () => void
-  onUnhandled: (action: string) => void
+  onUnhandled: (action: OrderAction) => void
 }
 
 export function useOrderActionBar({
@@ -55,14 +56,13 @@ export function useOrderActionBar({
     }
   }
 
-  const bulkCompleteActions: Record<
-    string,
+  const bulkCompleteActions: Partial<Record<OrderAction,
     {
       mutation: typeof completeReturnMutation
       successMessage: string
       errorMessage: string
     }
-  > = {
+  >> = {
     completeReturn: {
       mutation: completeReturnMutation,
       successMessage: '반품이 완료 처리되었습니다.',
@@ -75,7 +75,7 @@ export function useOrderActionBar({
     },
   }
 
-  const handleAction = (action: string) => {
+  const handleAction = (action: OrderAction) => {
     if (selectedIds.length === 0) {
       onSelectionEmpty()
       return

--- a/apps/seller/src/features/order/order-table/order-table.ui.tsx
+++ b/apps/seller/src/features/order/order-table/order-table.ui.tsx
@@ -38,6 +38,14 @@ function flattenOrders(orders: OrderItem[]): FlatOrderRow[] {
   })
 }
 
+interface TrackingOpenArgs {
+  orderNumber: string
+  orderId: number
+  orderItemIds: number[]
+  courier?: CourierName | null
+  trackingNumber?: string | null
+}
+
 interface OrderTableProps {
   tab: OrderStatusTab
   orders: OrderItem[]
@@ -48,12 +56,7 @@ interface OrderTableProps {
   onToggleAll: () => void
   onToggleOne: (orderNumber: string) => void
   onToggleProduct: (productKey: string, orderNumber: string) => void
-  onTrackingOpen?: (
-    mode: 'create' | 'edit',
-    orderNumber: string,
-    courier?: CourierName | null,
-    trackingNumber?: string | null,
-  ) => void
+  onTrackingOpen?: (mode: 'create' | 'edit', args: TrackingOpenArgs) => void
 }
 
 export function OrderTable({
@@ -330,16 +333,16 @@ export function OrderTable({
 interface TrackingNumberCellProps {
   row: Row<FlatOrderRow>
   tab: OrderStatusTab
-  onTrackingOpen?: (
-    mode: 'create' | 'edit',
-    orderNumber: string,
-    courier?: CourierName | null,
-    trackingNumber?: string | null,
-  ) => void
+  onTrackingOpen?: (mode: 'create' | 'edit', args: TrackingOpenArgs) => void
 }
 
 function TrackingNumberCell({ row, tab, onTrackingOpen }: TrackingNumberCellProps) {
   const { orderNumber, trackingNumber, courierName, returnStatus, exchangeStatus } = row.original
+
+  // list 응답이 orderId/orderItemIds를 노출하지 않아 orderNumber 캐스팅으로 대체.
+  // 응답 확장 시 row.original에서 직접 가져오도록 교체한다.
+  const orderId = Number(orderNumber)
+  const orderItemIds = [orderId]
 
   // 반품 탭: returnStatus에 따라 운송장 셀 렌더링
   if (tab === 'returned') {
@@ -353,7 +356,7 @@ function TrackingNumberCell({ row, tab, onTrackingOpen }: TrackingNumberCellProp
           variant="secondary-outlined"
           size="sm"
           title="입력"
-          onClick={() => onTrackingOpen?.('create', orderNumber)}
+          onClick={() => onTrackingOpen?.('create', { orderNumber, orderId, orderItemIds })}
         />
       )
     }
@@ -370,7 +373,13 @@ function TrackingNumberCell({ row, tab, onTrackingOpen }: TrackingNumberCellProp
             title="수정"
             className="w-56"
             onClick={() =>
-              onTrackingOpen?.('edit', orderNumber, courierName, trackingNumber)
+              onTrackingOpen?.('edit', {
+                orderNumber,
+                orderId,
+                orderItemIds,
+                courier: courierName,
+                trackingNumber,
+              })
             }
           />
         </div>
@@ -394,7 +403,7 @@ function TrackingNumberCell({ row, tab, onTrackingOpen }: TrackingNumberCellProp
           variant="secondary-outlined"
           size="sm"
           title="입력"
-          onClick={() => onTrackingOpen?.('create', orderNumber)}
+          onClick={() => onTrackingOpen?.('create', { orderNumber, orderId, orderItemIds })}
         />
       )
     }
@@ -411,7 +420,13 @@ function TrackingNumberCell({ row, tab, onTrackingOpen }: TrackingNumberCellProp
             title="수정"
             className="w-56"
             onClick={() =>
-              onTrackingOpen?.('edit', orderNumber, courierName, trackingNumber)
+              onTrackingOpen?.('edit', {
+                orderNumber,
+                orderId,
+                orderItemIds,
+                courier: courierName,
+                trackingNumber,
+              })
             }
           />
         </div>
@@ -425,7 +440,7 @@ function TrackingNumberCell({ row, tab, onTrackingOpen }: TrackingNumberCellProp
         variant="secondary-outlined"
         size="sm"
         title="입력"
-        onClick={() => onTrackingOpen?.('create', orderNumber)}
+        onClick={() => onTrackingOpen?.('create', { orderNumber, orderId, orderItemIds })}
       />
     )
   }
@@ -444,7 +459,13 @@ function TrackingNumberCell({ row, tab, onTrackingOpen }: TrackingNumberCellProp
             title="수정"
             className="w-56"
             onClick={() =>
-              onTrackingOpen?.('edit', orderNumber, courierName, trackingNumber)
+              onTrackingOpen?.('edit', {
+                orderNumber,
+                orderId,
+                orderItemIds,
+                courier: courierName,
+                trackingNumber,
+              })
             }
           />
         </div>

--- a/apps/seller/src/features/order/reason-input-modal/create-exchange.mutation.ts
+++ b/apps/seller/src/features/order/reason-input-modal/create-exchange.mutation.ts
@@ -1,15 +1,10 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 
 import { createExchange } from '@/entity/order/order.api'
-import { orderQueries } from '@/entity/order/order.query'
 
-export const useCreateExchangeMutation = () => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
+// 다건 병렬 호출 사용처에서 onSuccess invalidate 폭주를 피하기 위해
+// 무효화 책임은 호출부(useReasonAction)가 batch 종료 시 1회만 수행한다.
+export const useCreateExchangeMutation = () =>
+  useMutation({
     mutationFn: createExchange,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
-    },
   })
-}

--- a/apps/seller/src/features/order/reason-input-modal/create-exchange.mutation.ts
+++ b/apps/seller/src/features/order/reason-input-modal/create-exchange.mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { createExchange } from '@/entity/order/order.api'
+import { orderQueries } from '@/entity/order/order.query'
+
+export const useCreateExchangeMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: createExchange,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    },
+  })
+}

--- a/apps/seller/src/features/order/reason-input-modal/create-return.mutation.ts
+++ b/apps/seller/src/features/order/reason-input-modal/create-return.mutation.ts
@@ -1,15 +1,10 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 
 import { createReturn } from '@/entity/order/order.api'
-import { orderQueries } from '@/entity/order/order.query'
 
-export const useCreateReturnMutation = () => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
+// 다건 병렬 호출 사용처에서 onSuccess invalidate 폭주를 피하기 위해
+// 무효화 책임은 호출부(useReasonAction)가 batch 종료 시 1회만 수행한다.
+export const useCreateReturnMutation = () =>
+  useMutation({
     mutationFn: createReturn,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
-    },
   })
-}

--- a/apps/seller/src/features/order/reason-input-modal/create-return.mutation.ts
+++ b/apps/seller/src/features/order/reason-input-modal/create-return.mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { createReturn } from '@/entity/order/order.api'
+import { orderQueries } from '@/entity/order/order.query'
+
+export const useCreateReturnMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: createReturn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    },
+  })
+}

--- a/apps/seller/src/features/order/reason-input-modal/decide-cancel.mutation.ts
+++ b/apps/seller/src/features/order/reason-input-modal/decide-cancel.mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { decideCancel } from '@/entity/order/order.api'
+import { orderQueries } from '@/entity/order/order.query'
+
+export const useDecideCancelMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: decideCancel,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    },
+  })
+}

--- a/apps/seller/src/features/order/reason-input-modal/decide-return.mutation.ts
+++ b/apps/seller/src/features/order/reason-input-modal/decide-return.mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { decideReturn } from '@/entity/order/order.api'
+import { orderQueries } from '@/entity/order/order.query'
+
+export const useDecideReturnMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: decideReturn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    },
+  })
+}

--- a/apps/seller/src/features/order/reason-input-modal/index.ts
+++ b/apps/seller/src/features/order/reason-input-modal/index.ts
@@ -1,5 +1,6 @@
 export { ReasonInputModal } from './reason-input-modal.ui'
 export {
+  isReasonAction,
   REASON_REQUIRED_ACTIONS,
   type ReasonAction,
 } from './reason-input-modal.constant'

--- a/apps/seller/src/features/order/reason-input-modal/index.ts
+++ b/apps/seller/src/features/order/reason-input-modal/index.ts
@@ -3,3 +3,4 @@ export {
   REASON_REQUIRED_ACTIONS,
   type ReasonAction,
 } from './reason-input-modal.constant'
+export { useReasonAction } from './use-reason-action.hook'

--- a/apps/seller/src/features/order/reason-input-modal/reason-input-modal.constant.ts
+++ b/apps/seller/src/features/order/reason-input-modal/reason-input-modal.constant.ts
@@ -1,3 +1,5 @@
+import type { OrderAction } from '@/entity/order/order.type'
+
 /**
  * 주문상태 변경 사유입력 모달에서 사용하는 상수
  *
@@ -173,3 +175,7 @@ export const REASON_REQUIRED_ACTIONS: Set<string> = new Set<string>([
   'turnDownExchange',
   'holdExchange',
 ])
+
+/** 사유 입력이 필요한 액션인지 좁혀주는 타입 가드 */
+export const isReasonAction = (action: OrderAction): action is ReasonAction =>
+  REASON_REQUIRED_ACTIONS.has(action)

--- a/apps/seller/src/features/order/reason-input-modal/reason-input-modal.ui.tsx
+++ b/apps/seller/src/features/order/reason-input-modal/reason-input-modal.ui.tsx
@@ -10,13 +10,11 @@ import {
   DialogTitle,
   Select,
   Textarea,
-  toast,
 } from '@dessert/ui'
 
 import { ImageUploadGrid } from './image-upload-grid.ui'
 import {
   REASON_MODAL_TITLE,
-  REASON_TOAST_MESSAGE,
   REASON_TYPE_OPTIONS,
   ReasonAction,
 } from './reason-input-modal.constant'
@@ -47,7 +45,6 @@ export function ReasonInputModal({
 
   const title = REASON_MODAL_TITLE[action]
   const options = REASON_TYPE_OPTIONS[action]
-  const toastMessage = REASON_TOAST_MESSAGE[action]
 
   const isValid =
     reasonType !== '' && reasonDetail.length >= MIN_LENGTH
@@ -64,7 +61,6 @@ export function ReasonInputModal({
   const handleConfirm = () => {
     if (!isValid) return
     onConfirm({ reasonType, reasonDetail, images })
-    toast.success(toastMessage)
     onOpenChange(false)
   }
 

--- a/apps/seller/src/features/order/reason-input-modal/update-status.mutation.ts
+++ b/apps/seller/src/features/order/reason-input-modal/update-status.mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { updateOrderStatus } from '@/entity/order/order.api'
+import { orderQueries } from '@/entity/order/order.query'
+
+export const useUpdateOrderStatusMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: updateOrderStatus,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    },
+  })
+}

--- a/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
+++ b/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
@@ -1,0 +1,193 @@
+import { useState } from 'react'
+
+import { toast } from '@dessert/ui'
+
+import { useCreateExchangeMutation } from './create-exchange.mutation'
+import { useCreateReturnMutation } from './create-return.mutation'
+import { useDecideCancelMutation } from './decide-cancel.mutation'
+import { useDecideReturnMutation } from './decide-return.mutation'
+import {
+  REASON_TOAST_MESSAGE,
+  type ReasonAction,
+} from './reason-input-modal.constant'
+import { useUpdateOrderStatusMutation } from './update-status.mutation'
+
+interface ReasonInputData {
+  reasonType: string
+  reasonDetail: string
+  images: File[]
+}
+
+interface UseReasonActionParams {
+  selectedIds: string[]
+  onClearSelection: () => void
+}
+
+export function useReasonAction({
+  selectedIds,
+  onClearSelection,
+}: UseReasonActionParams) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [action, setAction] = useState<ReasonAction>('cancelOrder')
+
+  const createReturnMutation = useCreateReturnMutation()
+  const createExchangeMutation = useCreateExchangeMutation()
+  const decideReturnMutation = useDecideReturnMutation()
+  const decideCancelMutation = useDecideCancelMutation()
+  const updateStatusMutation = useUpdateOrderStatusMutation()
+
+  const isPending =
+    createReturnMutation.isPending ||
+    createExchangeMutation.isPending ||
+    decideReturnMutation.isPending ||
+    decideCancelMutation.isPending ||
+    updateStatusMutation.isPending
+
+  const open = (next: ReasonAction) => {
+    setAction(next)
+    setIsOpen(true)
+  }
+
+  const finishWithCleanup = () => {
+    onClearSelection()
+    setIsOpen(false)
+  }
+
+  // 반품/교환 요청 생성: 스펙 API는 1주문 당 1콜, 선택된 주문 수만큼 병렬 호출
+  const submitCreateRequest = async (
+    mutation: typeof createReturnMutation,
+    label: string,
+    reason: string | null,
+    sellerComment: string | null,
+  ) => {
+    const results = await Promise.allSettled(
+      selectedIds.map((orderNumber) => {
+        const id = Number(orderNumber)
+        return mutation.mutateAsync({
+          orderId: id,
+          orderItemIds: [id],
+          reason,
+          sellerComment,
+        })
+      }),
+    )
+
+    const successCount = results.filter(
+      (r) => r.status === 'fulfilled' && r.value.summary.successCount > 0,
+    ).length
+    const failCount = results.length - successCount
+
+    if (successCount > 0) finishWithCleanup()
+
+    if (failCount === 0) {
+      toast.success(`${successCount}건 ${label} 요청 완료`)
+    } else if (successCount > 0) {
+      toast.success(`${successCount}건 성공, ${failCount}건 실패`)
+    } else {
+      toast.error(`${label} 요청에 실패했습니다.`)
+    }
+  }
+
+  const submitDecideReturn = (
+    decisionType: 'APPROVE' | 'REJECT',
+    data: ReasonInputData,
+  ) => {
+    // TODO: 백엔드가 목록 응답에 returnId를 노출하면 selection에서 수집
+    // 임시: orderNumber 숫자 캐스팅을 returnId로 사용
+    const returnIds = selectedIds
+      .map((id) => Number(id))
+      .filter((n) => !Number.isNaN(n))
+    const reason = [data.reasonType, data.reasonDetail]
+      .filter(Boolean)
+      .join(' - ')
+
+    decideReturnMutation.mutate(
+      { returnIds, decisionType, reason: reason || null },
+      {
+        onSuccess: () => {
+          toast.success(REASON_TOAST_MESSAGE[action])
+          finishWithCleanup()
+        },
+        onError: () => toast.error('반품 처리에 실패했습니다.'),
+      },
+    )
+  }
+
+  const submitDecideCancel = (
+    decisionType: 'APPROVE' | 'REJECT',
+    data: ReasonInputData,
+  ) => {
+    // TODO: 백엔드가 목록 응답에 cancelId를 노출하면 selection에서 수집
+    // 임시: orderNumber 숫자 캐스팅을 cancelId로 사용
+    const cancelIds = selectedIds
+      .map((id) => Number(id))
+      .filter((n) => !Number.isNaN(n))
+    const reason = [data.reasonType, data.reasonDetail]
+      .filter(Boolean)
+      .join(' - ')
+
+    decideCancelMutation.mutate(
+      { cancelIds, decisionType, reason: reason || null },
+      {
+        onSuccess: () => {
+          toast.success(REASON_TOAST_MESSAGE[action])
+          finishWithCleanup()
+        },
+        onError: () => toast.error('주문 취소 처리에 실패했습니다.'),
+      },
+    )
+  }
+
+  const submitUpdateStatus = (data: ReasonInputData) => {
+    updateStatusMutation.mutate(
+      {
+        orderNumbers: selectedIds,
+        reasonType: data.reasonType,
+        reasonDetail: data.reasonDetail,
+        images: data.images,
+      },
+      {
+        onSuccess: onClearSelection,
+        onError: () => toast.error('주문 상태 변경에 실패했습니다.'),
+      },
+    )
+  }
+
+  const handleConfirm = (data: ReasonInputData) => {
+    switch (action) {
+      case 'requestReturn':
+        return void submitCreateRequest(
+          createReturnMutation,
+          '반품',
+          data.reasonType || null,
+          data.reasonDetail || null,
+        )
+      case 'requestExchange':
+        return void submitCreateRequest(
+          createExchangeMutation,
+          '교환',
+          data.reasonType || null,
+          data.reasonDetail || null,
+        )
+      case 'approveReturn':
+        return submitDecideReturn('APPROVE', data)
+      case 'rejectReturn':
+        return submitDecideReturn('REJECT', data)
+      case 'approveCancellation':
+        return submitDecideCancel('APPROVE', data)
+      case 'rejectCancellation':
+        return submitDecideCancel('REJECT', data)
+      default:
+        return submitUpdateStatus(data)
+    }
+  }
+
+  return {
+    isOpen,
+    setIsOpen,
+    action,
+    open,
+    handleConfirm,
+    isPending,
+  }
+}

--- a/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
+++ b/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
@@ -6,8 +6,6 @@ import { toast } from '@dessert/ui'
 
 import { useCreateExchangeMutation } from './create-exchange.mutation'
 import { useCreateReturnMutation } from './create-return.mutation'
-import { useDecideCancelMutation } from './decide-cancel.mutation'
-import { useDecideReturnMutation } from './decide-return.mutation'
 import {
   REASON_TOAST_MESSAGE,
   type ReasonAction,
@@ -26,9 +24,6 @@ interface UseReasonActionParams {
   onClearSelection: () => void
 }
 
-const buildReason = (data: ReasonInputData) =>
-  [data.reasonType, data.reasonDetail].filter(Boolean).join(' - ') || null
-
 export function useReasonAction({
   selectedIds,
   onClearSelection,
@@ -39,15 +34,11 @@ export function useReasonAction({
 
   const createReturnMutation = useCreateReturnMutation()
   const createExchangeMutation = useCreateExchangeMutation()
-  const decideReturnMutation = useDecideReturnMutation()
-  const decideCancelMutation = useDecideCancelMutation()
   const updateStatusMutation = useUpdateOrderStatusMutation()
 
   const isPending =
     createReturnMutation.isPending ||
     createExchangeMutation.isPending ||
-    decideReturnMutation.isPending ||
-    decideCancelMutation.isPending ||
     updateStatusMutation.isPending
 
   const open = (next: ReasonAction) => {
@@ -98,48 +89,11 @@ export function useReasonAction({
     }
   }
 
-  const submitDecideReturn = (
-    decisionType: 'APPROVE' | 'REJECT',
-    data: ReasonInputData,
-  ) => {
-    // TODO: 백엔드가 목록 응답에 returnId를 노출하면 selection에서 수집
-    // 임시: orderNumber 숫자 캐스팅을 returnId로 사용
-    const returnIds = selectedIds
-      .map((id) => Number(id))
-      .filter((n) => !Number.isNaN(n))
-
-    decideReturnMutation.mutate(
-      { returnIds, decisionType, reason: buildReason(data) },
-      {
-        onSuccess: () => {
-          toast.success(REASON_TOAST_MESSAGE[action])
-          finishWithCleanup()
-        },
-        onError: () => toast.error('반품 처리에 실패했습니다.'),
-      },
-    )
-  }
-
-  const submitDecideCancel = (
-    decisionType: 'APPROVE' | 'REJECT',
-    data: ReasonInputData,
-  ) => {
-    // TODO: 백엔드가 목록 응답에 cancelId를 노출하면 selection에서 수집
-    // 임시: orderNumber 숫자 캐스팅을 cancelId로 사용
-    const cancelIds = selectedIds
-      .map((id) => Number(id))
-      .filter((n) => !Number.isNaN(n))
-
-    decideCancelMutation.mutate(
-      { cancelIds, decisionType, reason: buildReason(data) },
-      {
-        onSuccess: () => {
-          toast.success(REASON_TOAST_MESSAGE[action])
-          finishWithCleanup()
-        },
-        onError: () => toast.error('주문 취소 처리에 실패했습니다.'),
-      },
-    )
+  // 백엔드가 목록 응답에 returnId/cancelId를 노출하기 전까지 호출 차단.
+  // orderNumber를 ID로 캐스팅해 보내면 다른 건이 처리될 위험이 있어 안내 토스트만 노출.
+  const notifyDecisionPending = () => {
+    toast.error('아직 준비 중인 기능입니다.')
+    finishWithCleanup()
   }
 
   const submitUpdateStatus = (data: ReasonInputData) => {
@@ -177,13 +131,10 @@ export function useReasonAction({
           data.reasonDetail || null,
         )
       case 'approveReturn':
-        return submitDecideReturn('APPROVE', data)
       case 'rejectReturn':
-        return submitDecideReturn('REJECT', data)
       case 'approveCancellation':
-        return submitDecideCancel('APPROVE', data)
       case 'rejectCancellation':
-        return submitDecideCancel('REJECT', data)
+        return notifyDecisionPending()
       default:
         return submitUpdateStatus(data)
     }

--- a/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
+++ b/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 
 import { toast } from '@dessert/ui'
 
+import { MUTATION_BATCH_SIZE } from '@/entity/order'
 import { useCreateExchangeMutation } from './create-exchange.mutation'
 import { useCreateReturnMutation } from './create-return.mutation'
 import {
@@ -12,6 +13,7 @@ import {
 } from './reason-input-modal.constant'
 import { useUpdateOrderStatusMutation } from './update-status.mutation'
 import { orderQueries } from '@/entity/order/order.query'
+import { settledInBatches } from '@/shared/utils/promise'
 
 interface ReasonInputData {
   reasonType: string
@@ -68,15 +70,16 @@ export function useReasonAction({
       return
     }
 
-    const results = await Promise.allSettled(
-      targetOrderIds.map((id) =>
+    const results = await settledInBatches(
+      targetOrderIds,
+      MUTATION_BATCH_SIZE,
+      (id) =>
         mutation.mutateAsync({
           orderId: id,
           orderItemIds: [id],
           reason,
           sellerComment,
         }),
-      ),
     )
 
     const successCount = results.filter(

--- a/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
+++ b/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
@@ -58,22 +58,31 @@ export function useReasonAction({
     reason: string | null,
     sellerComment: string | null,
   ) => {
+    const targetOrderIds = selectedIds
+      .map((orderNumber) => Number(orderNumber))
+      .filter((id) => Number.isFinite(id))
+    const invalidCount = selectedIds.length - targetOrderIds.length
+
+    if (targetOrderIds.length === 0) {
+      toast.error('유효한 주문이 없습니다.')
+      return
+    }
+
     const results = await Promise.allSettled(
-      selectedIds.map((orderNumber) => {
-        const id = Number(orderNumber)
-        return mutation.mutateAsync({
+      targetOrderIds.map((id) =>
+        mutation.mutateAsync({
           orderId: id,
           orderItemIds: [id],
           reason,
           sellerComment,
-        })
-      }),
+        }),
+      ),
     )
 
     const successCount = results.filter(
       (r) => r.status === 'fulfilled' && r.value.summary.successCount > 0,
     ).length
-    const failCount = results.length - successCount
+    const failCount = results.length - successCount + invalidCount
 
     if (successCount > 0) {
       finishWithCleanup()

--- a/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
+++ b/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
@@ -23,6 +23,9 @@ interface UseReasonActionParams {
   onClearSelection: () => void
 }
 
+const buildReason = (data: ReasonInputData) =>
+  [data.reasonType, data.reasonDetail].filter(Boolean).join(' - ') || null
+
 export function useReasonAction({
   selectedIds,
   onClearSelection,
@@ -97,12 +100,9 @@ export function useReasonAction({
     const returnIds = selectedIds
       .map((id) => Number(id))
       .filter((n) => !Number.isNaN(n))
-    const reason = [data.reasonType, data.reasonDetail]
-      .filter(Boolean)
-      .join(' - ')
 
     decideReturnMutation.mutate(
-      { returnIds, decisionType, reason: reason || null },
+      { returnIds, decisionType, reason: buildReason(data) },
       {
         onSuccess: () => {
           toast.success(REASON_TOAST_MESSAGE[action])
@@ -122,12 +122,9 @@ export function useReasonAction({
     const cancelIds = selectedIds
       .map((id) => Number(id))
       .filter((n) => !Number.isNaN(n))
-    const reason = [data.reasonType, data.reasonDetail]
-      .filter(Boolean)
-      .join(' - ')
 
     decideCancelMutation.mutate(
-      { cancelIds, decisionType, reason: reason || null },
+      { cancelIds, decisionType, reason: buildReason(data) },
       {
         onSuccess: () => {
           toast.success(REASON_TOAST_MESSAGE[action])

--- a/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
+++ b/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
@@ -147,7 +147,10 @@ export function useReasonAction({
         images: data.images,
       },
       {
-        onSuccess: onClearSelection,
+        onSuccess: () => {
+          toast.success(REASON_TOAST_MESSAGE[action])
+          finishWithCleanup()
+        },
         onError: () => toast.error('주문 상태 변경에 실패했습니다.'),
       },
     )

--- a/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
+++ b/apps/seller/src/features/order/reason-input-modal/use-reason-action.hook.ts
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 
+import { useQueryClient } from '@tanstack/react-query'
+
 import { toast } from '@dessert/ui'
 
 import { useCreateExchangeMutation } from './create-exchange.mutation'
@@ -11,6 +13,7 @@ import {
   type ReasonAction,
 } from './reason-input-modal.constant'
 import { useUpdateOrderStatusMutation } from './update-status.mutation'
+import { orderQueries } from '@/entity/order/order.query'
 
 interface ReasonInputData {
   reasonType: string
@@ -30,6 +33,7 @@ export function useReasonAction({
   selectedIds,
   onClearSelection,
 }: UseReasonActionParams) {
+  const queryClient = useQueryClient()
   const [isOpen, setIsOpen] = useState(false)
   const [action, setAction] = useState<ReasonAction>('cancelOrder')
 
@@ -80,7 +84,10 @@ export function useReasonAction({
     ).length
     const failCount = results.length - successCount
 
-    if (successCount > 0) finishWithCleanup()
+    if (successCount > 0) {
+      finishWithCleanup()
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    }
 
     if (failCount === 0) {
       toast.success(`${successCount}건 ${label} 요청 완료`)

--- a/apps/seller/src/features/order/tracking-number-modal/create-shipment.mutation.ts
+++ b/apps/seller/src/features/order/tracking-number-modal/create-shipment.mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { createShipment } from '@/entity/order/order.api'
+import { orderQueries } from '@/entity/order/order.query'
+
+export const useCreateShipmentMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: createShipment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    },
+  })
+}

--- a/apps/seller/src/features/order/tracking-number-modal/index.ts
+++ b/apps/seller/src/features/order/tracking-number-modal/index.ts
@@ -1,1 +1,2 @@
 export { TrackingNumberModal } from './tracking-number-modal.ui'
+export { useTrackingFlow } from './use-tracking-flow.hook'

--- a/apps/seller/src/features/order/tracking-number-modal/update-shipment.mutation.ts
+++ b/apps/seller/src/features/order/tracking-number-modal/update-shipment.mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { updateShipment } from '@/entity/order/order.api'
+import { orderQueries } from '@/entity/order/order.query'
+
+export const useUpdateShipmentMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: updateShipment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
+    },
+  })
+}

--- a/apps/seller/src/features/order/tracking-number-modal/use-tracking-flow.hook.ts
+++ b/apps/seller/src/features/order/tracking-number-modal/use-tracking-flow.hook.ts
@@ -9,8 +9,13 @@ import { useUpdateShipmentMutation } from './update-shipment.mutation'
 
 type TrackingMode = 'create' | 'edit'
 
-interface TrackingTarget {
+// 표시용(orderNumber)과 API 식별자(orderId/orderItemIds)를 분리해 보관한다.
+// 호출부에서 두 값을 명시적으로 전달하므로, 향후 백엔드가 목록 응답에 ID를 노출하면
+// hook 내부 변경 없이 호출부 한 곳만 수정하면 됨.
+export interface TrackingTarget {
   orderNumber: string
+  orderId: number
+  orderItemIds: number[]
   courier?: CourierName | null
   trackingNumber?: string | null
 }
@@ -26,29 +31,23 @@ export function useTrackingFlow() {
   const isPending =
     createShipmentMutation.isPending || updateShipmentMutation.isPending
 
-  const open = (
-    nextMode: TrackingMode,
-    orderNumber: string,
-    courier?: CourierName | null,
-    trackingNumber?: string | null,
-  ) => {
+  const open = (nextMode: TrackingMode, next: TrackingTarget) => {
     setMode(nextMode)
-    setTarget({ orderNumber, courier, trackingNumber })
+    setTarget(next)
     setIsOpen(true)
   }
 
   const handleConfirm = (courier: CourierName, trackingNumber: string) => {
-    if (!target?.orderNumber) return
-    const id = Number(target.orderNumber)
+    if (!target) return
 
-    if (Number.isNaN(id)) {
-      toast.error('유효하지 않은 주문번호입니다.')
+    if (!Number.isFinite(target.orderId) || target.orderItemIds.length === 0) {
+      toast.error('유효하지 않은 주문 정보입니다.')
       return
     }
 
     const payload = {
-      orderId: id,
-      orderItemIds: [id],
+      orderId: target.orderId,
+      orderItemIds: target.orderItemIds,
       courierName: courier,
       trackingNumber,
     }

--- a/apps/seller/src/features/order/tracking-number-modal/use-tracking-flow.hook.ts
+++ b/apps/seller/src/features/order/tracking-number-modal/use-tracking-flow.hook.ts
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+
+import { toast } from '@dessert/ui'
+
+import type { CourierName } from '@/entity/order/order.type'
+
+import { useCreateShipmentMutation } from './create-shipment.mutation'
+import { useUpdateShipmentMutation } from './update-shipment.mutation'
+
+type TrackingMode = 'create' | 'edit'
+
+interface TrackingTarget {
+  orderNumber: string
+  courier?: CourierName | null
+  trackingNumber?: string | null
+}
+
+export function useTrackingFlow() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [mode, setMode] = useState<TrackingMode>('create')
+  const [target, setTarget] = useState<TrackingTarget | null>(null)
+
+  const createShipmentMutation = useCreateShipmentMutation()
+  const updateShipmentMutation = useUpdateShipmentMutation()
+
+  const isPending =
+    createShipmentMutation.isPending || updateShipmentMutation.isPending
+
+  const open = (
+    nextMode: TrackingMode,
+    orderNumber: string,
+    courier?: CourierName | null,
+    trackingNumber?: string | null,
+  ) => {
+    setMode(nextMode)
+    setTarget({ orderNumber, courier, trackingNumber })
+    setIsOpen(true)
+  }
+
+  const handleConfirm = (courier: CourierName, trackingNumber: string) => {
+    if (!target?.orderNumber) return
+    const id = Number(target.orderNumber)
+
+    if (Number.isNaN(id)) {
+      toast.error('유효하지 않은 주문번호입니다.')
+      return
+    }
+
+    const payload = {
+      orderId: id,
+      orderItemIds: [id],
+      courierName: courier,
+      trackingNumber,
+    }
+
+    if (mode === 'edit') {
+      updateShipmentMutation.mutate(payload, {
+        onSuccess: () => {
+          toast.success('운송장 정보가 수정되었습니다.')
+          setIsOpen(false)
+        },
+        onError: () => toast.error('운송장 수정에 실패했습니다.'),
+      })
+      return
+    }
+
+    createShipmentMutation.mutate(payload, {
+      onSuccess: (result) => {
+        const { successCount, failCount } = result.summary
+        if (failCount === 0) {
+          toast.success('운송장 정보가 저장되었습니다.')
+          setIsOpen(false)
+        } else if (successCount > 0) {
+          toast.success(`${successCount}건 등록 성공, ${failCount}건 실패`)
+        } else {
+          toast.error('운송장 저장에 실패했습니다.')
+        }
+      },
+      onError: () => toast.error('운송장 저장에 실패했습니다.'),
+    })
+  }
+
+  return {
+    isOpen,
+    setIsOpen,
+    mode,
+    target,
+    open,
+    handleConfirm,
+    isPending,
+  }
+}

--- a/apps/seller/src/features/order/tracking-number-modal/use-tracking-flow.hook.ts
+++ b/apps/seller/src/features/order/tracking-number-modal/use-tracking-flow.hook.ts
@@ -70,7 +70,9 @@ export function useTrackingFlow() {
           toast.success('운송장 정보가 저장되었습니다.')
           setIsOpen(false)
         } else if (successCount > 0) {
+          // 부분 성공: 모달을 닫아 재시도 시 성공 건이 중복 전송되는 것을 막는다.
           toast.success(`${successCount}건 등록 성공, ${failCount}건 실패`)
+          setIsOpen(false)
         } else {
           toast.error('운송장 저장에 실패했습니다.')
         }

--- a/apps/seller/src/pages/orders/all-orders/all-orders-page.tsx
+++ b/apps/seller/src/pages/orders/all-orders/all-orders-page.tsx
@@ -21,8 +21,7 @@ import {
   useOrderSelection,
 } from '@/features/order/order-table'
 import {
-  REASON_REQUIRED_ACTIONS,
-  ReasonAction,
+  isReasonAction,
   ReasonInputModal,
   useReasonAction,
 } from '@/features/order/reason-input-modal'
@@ -109,8 +108,8 @@ function AllOrdersPage() {
       onShowDetail: () => setDetailOpen(true),
       onSelectionEmpty: () => setAlertOpen(true),
       onUnhandled: (action) => {
-        if (REASON_REQUIRED_ACTIONS.has(action)) {
-          openReason(action as ReasonAction)
+        if (isReasonAction(action)) {
+          openReason(action)
         }
       },
     })

--- a/apps/seller/src/pages/orders/all-orders/all-orders-page.tsx
+++ b/apps/seller/src/pages/orders/all-orders/all-orders-page.tsx
@@ -1,35 +1,35 @@
 import { useState } from 'react'
 
-import {
-  keepPreviousData,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { useSearchParams } from 'react-router-dom'
 
-import { updateOrderStatus } from '@/entity/order/order.api'
 import { orderQueries } from '@/entity/order/order.query'
 import {
-  CourierName,
   OrderStatusCount,
   OrderStatusTab,
 } from '@/entity/order/order.type'
-import { toast } from '@dessert/ui'
-import { OrderActionBar } from '@/features/order/order-action-bar/order-action-bar.ui'
-import { OrderDetailModal } from '@/features/order/order-detail-modal/order-detail-modal.ui'
-import { useOrderFilter } from '@/features/order/order-filters/order-filters.hook'
-import { OrderFilters } from '@/features/order/order-filters/order-filters.ui'
+import {
+  OrderActionBar,
+  useOrderActionBar,
+} from '@/features/order/order-action-bar'
+import { OrderDetailModal } from '@/features/order/order-detail-modal'
+import { OrderFilters, useOrderFilter } from '@/features/order/order-filters'
+import { OrderSelectAlertModal } from '@/features/order/order-select-alert-modal'
+import { OrderStatusTabs } from '@/features/order/order-status-tabs'
+import {
+  OrderTable,
+  useOrderSelection,
+} from '@/features/order/order-table'
 import {
   REASON_REQUIRED_ACTIONS,
   ReasonAction,
-} from '@/features/order/reason-input-modal/reason-input-modal.constant'
-import { ReasonInputModal } from '@/features/order/reason-input-modal/reason-input-modal.ui'
-import { OrderSelectAlertModal } from '@/features/order/order-select-alert-modal/order-select-alert-modal.ui'
-import { OrderStatusTabs } from '@/features/order/order-status-tabs/order-status-tabs.ui'
-import { useOrderSelection } from '@/features/order/order-table/order-selection.hook'
-import { OrderTable } from '@/features/order/order-table/order-table.ui'
-import { TrackingNumberModal } from '@/features/order/tracking-number-modal/tracking-number-modal.ui'
+  ReasonInputModal,
+  useReasonAction,
+} from '@/features/order/reason-input-modal'
+import {
+  TrackingNumberModal,
+  useTrackingFlow,
+} from '@/features/order/tracking-number-modal'
 
 const VALID_TABS: OrderStatusTab[] = [
   'all',
@@ -54,18 +54,8 @@ const DEFAULT_STATUS_COUNT: OrderStatusCount = {
 }
 
 function AllOrdersPage() {
-  const queryClient = useQueryClient()
   const [detailOpen, setDetailOpen] = useState(false)
   const [alertOpen, setAlertOpen] = useState(false)
-  const [reasonModalOpen, setReasonModalOpen] = useState(false)
-  const [reasonAction, setReasonAction] = useState<ReasonAction>('cancelOrder')
-  const [trackingModalOpen, setTrackingModalOpen] = useState(false)
-  const [trackingMode, setTrackingMode] = useState<'create' | 'edit'>('create')
-  const [trackingTarget, setTrackingTarget] = useState<{
-    orderNumber: string
-    courier?: CourierName | null
-    trackingNumber?: string | null
-  } | null>(null)
   const [searchParams, setSearchParams] = useSearchParams()
   const statusParam = searchParams.get('status')
   const selectedTab: OrderStatusTab = VALID_TABS.includes(
@@ -89,17 +79,6 @@ function AllOrdersPage() {
   })
   const orders = data?.content ?? []
 
-  const updateStatusMutation = useMutation({
-    mutationFn: updateOrderStatus,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: orderQueries.all() })
-      selectionReset()
-    },
-    onError: () => {
-      toast.error('주문 상태 변경에 실패했습니다.')
-    },
-  })
-
   const {
     selectedIds,
     productSelectedIds,
@@ -110,6 +89,31 @@ function AllOrdersPage() {
     toggleProduct,
     reset: selectionReset,
   } = useOrderSelection(orders)
+
+  const {
+    isOpen: isReasonOpen,
+    setIsOpen: setReasonOpen,
+    action: reasonAction,
+    open: openReason,
+    handleConfirm: handleReasonConfirm,
+  } = useReasonAction({
+    selectedIds,
+    onClearSelection: selectionReset,
+  })
+
+  const tracking = useTrackingFlow()
+
+  const { handleAction: handleActionBar } = useOrderActionBar({
+      selectedIds,
+      onClearSelection: selectionReset,
+      onShowDetail: () => setDetailOpen(true),
+      onSelectionEmpty: () => setAlertOpen(true),
+      onUnhandled: (action) => {
+        if (REASON_REQUIRED_ACTIONS.has(action)) {
+          openReason(action as ReasonAction)
+        }
+      },
+    })
 
   const handleTabChange = (tab: OrderStatusTab) => {
     filtersReset(tab)
@@ -130,70 +134,6 @@ function AllOrdersPage() {
   const handlePageChange = (page: number) => {
     selectionReset()
     setAppliedFilters((prev) => ({ ...prev, page: String(page - 1) }))
-  }
-
-  const handleAction = (action: string) => {
-    if (action === 'detailView') {
-      if (selectedIds.length === 0) {
-        setAlertOpen(true)
-        return
-      }
-      setDetailOpen(true)
-      return
-    }
-
-    // TODO(feat/order-action-mutations): 후속 PR에서 mutation hook 연결
-    if (
-      action === 'confirmOrder' ||
-      action === 'completeReturn' ||
-      action === 'completeExchange'
-    ) {
-      if (selectedIds.length === 0) {
-        setAlertOpen(true)
-      }
-      return
-    }
-
-    if (REASON_REQUIRED_ACTIONS.has(action)) {
-      if (selectedIds.length === 0) {
-        setAlertOpen(true)
-        return
-      }
-      setReasonAction(action as ReasonAction)
-      setReasonModalOpen(true)
-    }
-  }
-
-  const handleReasonConfirm = (data: {
-    reasonType: string
-    reasonDetail: string
-    images: File[]
-  }) => {
-    updateStatusMutation.mutate({
-      orderNumbers: selectedIds,
-      reasonType: data.reasonType,
-      reasonDetail: data.reasonDetail,
-      images: data.images,
-    })
-  }
-
-  const handleTrackingOpen = (
-    mode: 'create' | 'edit',
-    orderNumber: string,
-    courier?: CourierName | null,
-    trackingNumber?: string | null,
-  ) => {
-    setTrackingMode(mode)
-    setTrackingTarget({ orderNumber, courier, trackingNumber })
-    setTrackingModalOpen(true)
-  }
-
-  // TODO(feat/order-action-mutations): 후속 PR에서 운송장 mutation 연결
-  const handleTrackingConfirm = (
-    _courier: CourierName,
-    _trackingNumber: string,
-  ) => {
-    setTrackingModalOpen(false)
   }
 
   const currentPage = appliedFilters.page ? Number(appliedFilters.page) + 1 : 1
@@ -219,7 +159,7 @@ function AllOrdersPage() {
       <section className="mt-10 rounded-10 border bg-white">
         <OrderActionBar
           tab={currentTab}
-          onAction={handleAction}
+          onAction={handleActionBar}
           selectedCount={selectedIds.length}
           totalCount={totalCount}
           currentPage={currentPage}
@@ -237,7 +177,7 @@ function AllOrdersPage() {
           onToggleAll={toggleAll}
           onToggleOne={toggleOne}
           onToggleProduct={toggleProduct}
-          onTrackingOpen={handleTrackingOpen}
+          onTrackingOpen={tracking.open}
         />
       </section>
 
@@ -248,19 +188,19 @@ function AllOrdersPage() {
       />
       <OrderSelectAlertModal open={alertOpen} onOpenChange={setAlertOpen} />
       <ReasonInputModal
-        open={reasonModalOpen}
-        onOpenChange={setReasonModalOpen}
+        open={isReasonOpen}
+        onOpenChange={setReasonOpen}
         action={reasonAction}
         onConfirm={handleReasonConfirm}
       />
       <TrackingNumberModal
-        key={trackingTarget?.orderNumber ?? ''}
-        open={trackingModalOpen}
-        onOpenChange={setTrackingModalOpen}
-        mode={trackingMode}
-        defaultCourier={trackingTarget?.courier}
-        defaultTrackingNumber={trackingTarget?.trackingNumber}
-        onConfirm={handleTrackingConfirm}
+        key={tracking.target?.orderNumber ?? ''}
+        open={tracking.isOpen}
+        onOpenChange={tracking.setIsOpen}
+        mode={tracking.mode}
+        defaultCourier={tracking.target?.courier}
+        defaultTrackingNumber={tracking.target?.trackingNumber}
+        onConfirm={tracking.handleConfirm}
       />
     </div>
   )

--- a/apps/seller/src/shared/utils/promise.ts
+++ b/apps/seller/src/shared/utils/promise.ts
@@ -1,0 +1,21 @@
+/**
+ * 다건 비동기 작업을 chunk 단위로 끊어 호출하면서 모든 결과(성공/실패)를 누적한다.
+ *
+ * @example
+ * const results = await settledInBatches(ids, 10, (id) => api.update(id))
+ */
+export async function settledInBatches<T, R>(
+  items: T[],
+  size: number,
+  fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = []
+
+  for (let i = 0; i < items.length; i += size) {
+    const chunk = items.slice(i, i + size)
+    const settled = await Promise.allSettled(chunk.map(fn))
+    results.push(...settled)
+  }
+
+  return results
+}


### PR DESCRIPTION
## 이슈 번호
Refs: #180 

## 분리 컨텍스트
```mermaid
flowchart LR
    D[develop] --> E[feat/order-entity<br/>PR #1]
    E --> M[feat/order-action-mutations<br/>이 PR]
    M --> U[feat/order-table-ux<br/>PR #3]
    style M fill:#ffe082,stroke:#f57f17,stroke-width:2px
```
PR #191(`feat/order-api`)을 레이어 경계로 3개 stacked PR로 분리한 두 번째 PR

## 작업 내용 및 테스트 방법
### 주문 액션 mutation 9종 연동
발주확인, 반품 완료, 교환 완료, 반품 등록, 교환 등록, 반품 결정, 취소 결정, 운송장 등록, 운송장 수정.

### features 레벨 orchestration 훅 도입
모달 state와 다수 mutation 디스패칭이 페이지 한 파일에 몰려있던 구조를 같은 플로우에 묶이는 state/mutation 단위로 features 슬라이스 훅에 분산.

#### useOrderActionBar
- 액션바 dispatcher와 발주확인, 반품 완료, 교환 완료 mutation, bulk handler 담당.
- 미처리 액션은 `onUnhandled` 콜백으로 호출부에 위임하여 훅이 모든 액션 분기를 알 필요 없이 액션바 자신이 책임지는 것만 처리.

#### useReasonAction
사유 모달 state와 5개 mutation (createReturn, createExchange, decideReturn, decideCancel, updateStatus) 디스패처 담당.

#### useTrackingFlow
운송장 모달 state와 create, update shipment 담당

### Cross-slice 의존 정리
- `decideCancel` / `decideReturn`은 원래 `order-action-bar`에 있었지만 실제 트리거되는 슬라이스인 `reason-input-modal`로 이동
     - 호출부 슬라이스가 다른 슬라이스의 내부 mutation을 직접 import하지 않게 격리하기 위함.
- 슬라이스의 `index.ts`는 외부에서 직접 소비되는 심볼만 노출하고 wrapper 훅에 흡수된 mutation은 비공개로 둠
     - 외부에서 wrapper 내부 mutation을 우회 호출하는 경로 차단

### 페이지 호출부 연결 (entity PR의 TODO stub 해소)
- `all-orders-page.tsx`에서 entity PR이 박아둔 TODO stub을 위 3개 orchestration 훅 호출로 대체
- 페이지가 mutation 분기 로직을 알지 않고 라우트 조합 수준만 책임지도록 축소.

### 액션바 그룹 버튼 @dessert/ui Button 적용
- `order-action-bar.ui.tsx`의 group 버튼 `<button>` -> `@dessert/ui` `<Button>` 12줄 교체
- mutation 작업 중 함께 정비된 styling cleanup이라 본 PR에 포함.

## To reviewers
- FSD 컨벤션에 위배되는 부분 없는지 확인 부탁드립니다.
- mutation 훅의 `invalidateQueries` 범위가 적절한지 (`orderQueries.all()` 단위 일괄 무효화 vs 더 좁은 범위) 의견 환영합니다.