### PR TITLE
✨ Feat: Seller fixedLayout 구조 개선

### DIFF
--- a/apps/seller/src/shared/block/fixed-layout/fixed-layout.tsx
+++ b/apps/seller/src/shared/block/fixed-layout/fixed-layout.tsx
@@ -1,5 +1,4 @@
 import { LogoHeader } from '@dessert/ui'
-import { ScrollArea } from '@radix-ui/react-scroll-area'
 import { Outlet } from 'react-router-dom'
 
 import Lnb from '@/shared/block/lnb/lnb'
@@ -10,8 +9,8 @@ const FixedLayout = () => {
       <LogoHeader />
       <div className="flex h-[calc(100vh-80px)] w-full flex-row overflow-y-auto">
         <Lnb />
-        <main className="size-full max-w-[calc(100vw-240px)] overflow-y-auto bg-gray-50">
-          <div className="relative px-[90px] pt-40 pb-36">
+        <main className="flex-1 overflow-y-auto bg-gray-50">
+          <div className="relative px-[90px] pt-40">
             <Outlet />
           </div>
         </main>

--- a/apps/seller/src/shared/block/fixed-layout/fixed-layout.tsx
+++ b/apps/seller/src/shared/block/fixed-layout/fixed-layout.tsx
@@ -10,7 +10,7 @@ const FixedLayout = () => {
       <div className="flex h-[calc(100vh-80px)] w-full flex-row overflow-y-auto">
         <Lnb />
         <main className="flex-1 overflow-y-auto bg-gray-50">
-          <div className="relative px-[90px] pt-40">
+          <div className="relative p-40 px-[90px]">
             <Outlet />
           </div>
         </main>

--- a/apps/seller/src/shared/block/fixed-layout/fixed-layout.tsx
+++ b/apps/seller/src/shared/block/fixed-layout/fixed-layout.tsx
@@ -10,10 +10,10 @@ const FixedLayout = () => {
       <LogoHeader />
       <div className="flex h-[calc(100vh-80px)] w-full flex-row overflow-y-auto">
         <Lnb />
-        <main className="size-full max-w-[1240px] bg-gray-50">
-          <ScrollArea className="size-full px-[90px] py-40">
+        <main className="size-full max-w-[calc(100vw-240px)] overflow-y-auto bg-gray-50">
+          <div className="relative px-[90px] pt-40 pb-36">
             <Outlet />
-          </ScrollArea>
+          </div>
         </main>
       </div>
     </>

--- a/apps/seller/src/widgets/fixed-layout/fixed-layout.tsx
+++ b/apps/seller/src/widgets/fixed-layout/fixed-layout.tsx
@@ -7,10 +7,10 @@ export function FixedLayout() {
   return (
     <>
       <LogoHeader />
-      <div className="flex h-[calc(100vh-80px)] w-full flex-row overflow-y-auto">
+      <div className="flex h-[calc(100vh-80px)] w-full flex-row">
         <Lnb />
         <main className="flex-1 overflow-y-auto bg-gray-50">
-          <div className="relative px-[90px] pt-40">
+          <div className="relative p-40 px-[90px]">
             <Outlet />
           </div>
         </main>

--- a/apps/seller/src/widgets/fixed-layout/fixed-layout.tsx
+++ b/apps/seller/src/widgets/fixed-layout/fixed-layout.tsx
@@ -1,5 +1,4 @@
 import { LogoHeader } from '@dessert/ui'
-import { ScrollArea } from '@radix-ui/react-scroll-area'
 import { Outlet } from 'react-router-dom'
 
 import Lnb from '@/shared/block/lnb/lnb'
@@ -10,10 +9,10 @@ export function FixedLayout() {
       <LogoHeader />
       <div className="flex h-[calc(100vh-80px)] w-full flex-row overflow-y-auto">
         <Lnb />
-        <main className="size-full max-w-[1240px] bg-gray-50">
-          <ScrollArea className="size-full px-[90px] py-40">
+        <main className="flex-1 overflow-y-auto bg-gray-50">
+          <div className="relative px-[90px] pt-40">
             <Outlet />
-          </ScrollArea>
+          </div>
         </main>
       </div>
     </>


### PR DESCRIPTION
## 이슈 번호

closed #198 

## 작업 내용 및 테스트 방법

- main 태그의 max-width 대신 flex-1 적용으로 좌측 lnb영역 너비에 상관없이 유연하게 콘텐츠 영역을 채웠습니다
- ScrollArea 컴포넌트 제거로, overflow와 relative 속성이 함께 잡혀있어 상품 등록 페이지의 sticky 속성이 적용되지 않는 문제를 해결했습니다.
- fixedLayout 자체에 padding 40px로 공통 여백을 추가했습니다.
  - **상품 등록**의 경우 중복 여백이 잡혀있어 별도의 수정이 필요합니다.

## To reviewers
- seller 각 페이지 콘텐츠 영역이 여백 없이 꽉 채워지는지 확인해주세요!
- 각 페이지에 중첩 스크롤이 잡히지 않는지 확인해주세요!