### PR TITLE
🐛 Fix: Chip 컴포넌트 속성 추가 및 디자인 시안 통일

### DIFF
--- a/packages/ui/src/chip/chip.stories.tsx
+++ b/packages/ui/src/chip/chip.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
     },
     size: {
       control: 'select',
-      options: ['sm', 'md'],
+      options: ['sm', 'md', 'lg'],
     },
     closable: {
       control: 'boolean',
@@ -61,6 +61,14 @@ export const Small: Story = {
   args: {
     children: 'Small Chip',
     size: 'sm',
+    closable: false,
+  },
+}
+
+export const Large: Story = {
+  args: {
+    children: 'Large Chip',
+    size: 'lg',
     closable: false,
   },
 }

--- a/packages/ui/src/chip/chip.stories.tsx
+++ b/packages/ui/src/chip/chip.stories.tsx
@@ -84,14 +84,20 @@ export const AllVariants: Story = {
           Small
         </Chip>
         <Chip selected={false}>Default</Chip>
+        <Chip selected={false} size="lg">
+          Large
+        </Chip>
         <Chip selected>Active</Chip>
       </div>
       <div className="flex flex-wrap items-center gap-2">
         <Chip selected={false} size="sm" closable onClose={fn()}>
-          Closable
+          Small Closable
         </Chip>
         <Chip selected={false} closable onClose={fn()}>
-          Closable
+          Default Closable
+        </Chip>
+        <Chip selected={false} size="lg" closable onClose={fn()}>
+          Large Closable
         </Chip>
         <Chip selected closable onClose={fn()}>
           Closable Primary

--- a/packages/ui/src/chip/chip.tsx
+++ b/packages/ui/src/chip/chip.tsx
@@ -32,6 +32,7 @@ const Chip = ({
   const sizeClasses = {
     sm: 'px-2 py-1 typo-body-10-r rounded-full',
     md: 'px-3 py-1.5 typo-body-12-r rounded-full',
+    lg: 'px-12 py-6 typo-body-14-r rounded-full',
   }
 
   const closeClasses = {

--- a/packages/ui/src/chip/chip.tsx
+++ b/packages/ui/src/chip/chip.tsx
@@ -39,7 +39,7 @@ const Chip = ({
   const closeClasses = {
     sm: 'size-12',
     md: 'size-16',
-    lg: 'size-18',
+    lg: 'size-4.5',
   }
 
   return (

--- a/packages/ui/src/chip/chip.tsx
+++ b/packages/ui/src/chip/chip.tsx
@@ -61,7 +61,7 @@ const Chip = ({
           className="flex items-center justify-center transition-opacity hover:opacity-70"
           aria-label="닫기"
         >
-          <XIcon className={cn(closeClasses[size])} />
+          <XIcon className={closeClasses[size]} />
         </button>
       )}
     </span>

--- a/packages/ui/src/chip/chip.tsx
+++ b/packages/ui/src/chip/chip.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx'
 
 interface ChipProps {
   children: React.ReactNode
-  size?: 'sm' | 'md'
+  size?: 'sm' | 'md' | 'lg'
   closable?: boolean
   selected?: boolean
   onClose?: () => void

--- a/packages/ui/src/chip/chip.tsx
+++ b/packages/ui/src/chip/chip.tsx
@@ -1,5 +1,6 @@
 import { XIcon } from '@dessert/icons'
-import { clsx } from 'clsx'
+
+import { cn } from '../lib/utils'
 
 interface ChipProps {
   children: React.ReactNode
@@ -38,11 +39,12 @@ const Chip = ({
   const closeClasses = {
     sm: 'size-12',
     md: 'size-16',
+    lg: 'size-18',
   }
 
   return (
     <span
-      className={clsx(
+      className={cn(
         'inline-flex cursor-pointer items-center justify-center gap-1 border border-solid transition-colors duration-150',
         sizeClasses[size],
         selected
@@ -59,8 +61,7 @@ const Chip = ({
           className="flex items-center justify-center transition-opacity hover:opacity-70"
           aria-label="닫기"
         >
-          {/* <XIcon className={cn(closeClasses[size])} /> */}
-          <XIcon />
+          <XIcon className={cn(closeClasses[size])} />
         </button>
       )}
     </span>

--- a/packages/ui/src/chip/chip.tsx
+++ b/packages/ui/src/chip/chip.tsx
@@ -30,8 +30,8 @@ const Chip = ({
   }
 
   const sizeClasses = {
-    sm: 'px-2 py-1 typo-body-10-r rounded-full',
-    md: 'px-3 py-1.5 typo-body-12-r rounded-full',
+    sm: 'px-2.25 py-4 typo-body-10-r rounded-full',
+    md: 'px-12 py-6 typo-body-12-r rounded-full',
     lg: 'px-12 py-6 typo-body-14-r rounded-full',
   }
 


### PR DESCRIPTION
## 이슈 번호

closed #202 

## 작업 내용 및 테스트 방법

- Chip 컴포넌트에 lg size type 추가
  - 상품 등록 페이지의 Chip 디자인이 수정 되어 lg type 추가 (기존 sm, md type의 style은 변동 없음)
- 디자인 시안과 다른 padding값 수정
- 주석 처리되었던 close 버튼 복구 및 `clxs -> cn` 로 변경
- storybook 수정
  - lg size type 추가
 
<img width="407" height="100" alt="image" src="https://github.com/user-attachments/assets/e54ec28b-7284-48f5-8b3a-0614e6efeaf1" />


## To reviewers
- Figma 공통 컴포넌트 디자인과 일치하는지 확인 부탁드립니다. 