### PR TITLE
📦 Chore: .gitignore에 로컬 AI 에이전트 skill 폴더 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ dist-ssr
 
 *storybook.log
 storybook-static
+
+# Local AI agent skill folders (Claude Code / Gemini CLI / OpenAI Codex CLI)
+.claude/
+.gemini/
+.codex/


### PR DESCRIPTION
## 이슈 번호

Closes #233

## 작업 내용 및 테스트 방법

- .gitignore에 AI agent 스킬 폴더 추가
  - .claude/ (Claude Code)
  - .gemini/ (Gemini CLI)
  - .codex/ (OpenAI Codex CLI)

- 추가된 폴더가 정상적으로 무시되는지 확인