### PR TITLE
✨ Feat: 판매자 스토어 정보 수정 API 연동 및 폼 프리필 개발

### DIFF
--- a/apps/seller/src/entity/seller-info/index.ts
+++ b/apps/seller/src/entity/seller-info/index.ts
@@ -4,6 +4,7 @@ export {
   getStore,
   requestStoreNameChange,
   updateSellerAccount,
+  updateStore,
 } from './seller-info.api'
 export { BANK_CODES, getBankLabel } from './seller-info.const'
 export type { BankCode } from './seller-info.const'
@@ -12,6 +13,7 @@ export {
   useCheckStoreNameMutation,
   useRequestStoreNameChangeMutation,
   useUpdateSellerAccountMutation,
+  useUpdateStoreDetailMutation,
 } from './seller-info.query'
 export type {
   AccountVerificationDetail,

--- a/apps/seller/src/entity/seller-info/seller-info.api.ts
+++ b/apps/seller/src/entity/seller-info/seller-info.api.ts
@@ -8,6 +8,8 @@ import type {
   MyStoreSummary,
   SellerAccountUpdateRequest,
   StoreNameCheckResult,
+  UpdateStoreDetailInput,
+  UpdateStoreDetailResult,
   UpdateStoreNameRequest,
   UpdateStoreNameResult,
 } from './seller-info.type'
@@ -54,6 +56,32 @@ export async function requestStoreNameChange(
   }
 
   return data.result
+}
+
+export async function updateStore({
+  request,
+  profileImage,
+}: UpdateStoreDetailInput): Promise<UpdateStoreDetailResult> {
+  const formData = new FormData()
+  formData.append(
+    'request',
+    new Blob([JSON.stringify(request)], { type: 'application/json' }),
+  )
+  if (profileImage) {
+    formData.append('profileImage', profileImage)
+  }
+
+  const { data } = await client.put<
+    ApiResponse<{ store: UpdateStoreDetailResult }>
+  >('/api/v1/seller/stores', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+
+  if (!data.result) {
+    throw new Error(data.message ?? '스토어 정보 수정에 실패했습니다.')
+  }
+
+  return data.result.store
 }
 
 export async function getAccountVerification(): Promise<AccountVerificationDetail | null> {

--- a/apps/seller/src/entity/seller-info/seller-info.query.ts
+++ b/apps/seller/src/entity/seller-info/seller-info.query.ts
@@ -10,6 +10,7 @@ import {
   getStore,
   requestStoreNameChange,
   updateSellerAccount,
+  updateStore,
 } from './seller-info.api'
 
 export const sellerInfoQueries = {
@@ -30,6 +31,19 @@ export const sellerInfoQueries = {
 export function useCheckStoreNameMutation() {
   return useMutation({
     mutationFn: checkStoreName,
+  })
+}
+
+export function useUpdateStoreDetailMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: updateStore,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: sellerInfoQueries.store().queryKey,
+      })
+    },
   })
 }
 

--- a/apps/seller/src/entity/seller-info/seller-info.query.ts
+++ b/apps/seller/src/entity/seller-info/seller-info.query.ts
@@ -19,6 +19,8 @@ export const sellerInfoQueries = {
     queryOptions({
       queryKey: [...sellerInfoQueries.all(), 'store'],
       queryFn: getStore,
+      // 자동 재시도 대신 실패를 바로 노출하고 다시 시도 버튼으로 재요청한다.
+      retry: false,
     }),
   accountVerification: () =>
     queryOptions({

--- a/apps/seller/src/entity/seller-info/seller-info.type.ts
+++ b/apps/seller/src/entity/seller-info/seller-info.type.ts
@@ -50,9 +50,11 @@ export interface UpdateStoreNameResult {
 }
 
 export interface UpdateStoreDetailRequest {
-  introduce?: string
+  // 스토어명은 이 화면에서 수정 불가(별도 변경 신청 플로우)지만 PUT 명세상 필수라 현재 값을 그대로 전송.
+  storeName: string
+  introduce: string
   phoneNumber: string
-  subPhoneNumber?: string
+  subPhoneNumber: string
   email: string
   originAddress: string
   originAddressDetail: string

--- a/apps/seller/src/features/seller-info/seller-info-toast.ts
+++ b/apps/seller/src/features/seller-info/seller-info-toast.ts
@@ -14,10 +14,7 @@ export const sellerInfoToast = {
     toast.error('중복 확인 중 문제가 발생했어요', '잠시 후 다시 시도해주세요'),
 
   storeNameChangeError: () =>
-    toast.error(
-      '스토어명 변경 신청에 실패했어요',
-      '잠시 후 다시 시도해주세요',
-    ),
+    toast.error('스토어명 변경 신청에 실패했어요', '잠시 후 다시 시도해주세요'),
 
   accountInfoChangeSuccess: () => toast.success('계좌정보 변경을 완료했어요'),
 
@@ -38,4 +35,7 @@ export const sellerInfoToast = {
   saveSuccess: () => toast.success('변경사항이 저장되었어요'),
 
   saveValidationError: () => toast.error('작성되지 않은 항목이 있어요'),
+
+  storeInfoSaveError: () =>
+    toast.error('스토어 정보 수정에 실패했어요', '잠시 후 다시 시도해주세요'),
 }

--- a/apps/seller/src/features/seller-info/store-contact-address-form/store-contact-address-form.ui.tsx
+++ b/apps/seller/src/features/seller-info/store-contact-address-form/store-contact-address-form.ui.tsx
@@ -140,12 +140,17 @@ function AddressSection() {
   const {
     register,
     setValue,
+    watch,
     formState: { errors },
   } = useFormContext<StoreDetailFormValues>()
 
   const [postalCode, setPostalCode] = useState('')
   const [isPostalCodeSelected, setIsPostalCodeSelected] = useState(false)
   const openPostcode = useKakaoPostcodePopup()
+
+  // 우편번호를 새로 검색했거나, 이미 등록된 주소가 프리필된 경우 상세주소 편집 허용.
+  const hasAddress = watch('originAddress').trim().length > 0
+  const canEditAddressDetail = isPostalCodeSelected || hasAddress
 
   const handleClickPostalCodeSearch = () => {
     openPostcode({
@@ -204,7 +209,7 @@ function AddressSection() {
             label="출고지 상세주소"
             placeholder="1동 101호"
             required
-            disabled={!isPostalCodeSelected}
+            disabled={!canEditAddressDetail}
           />
           {errors.originAddressDetail && (
             <span className="typo-body-12-r text-error-500">

--- a/apps/seller/src/features/seller-info/store-info-form/store-info-form.ui.tsx
+++ b/apps/seller/src/features/seller-info/store-info-form/store-info-form.ui.tsx
@@ -1,37 +1,124 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Button } from '@dessert/ui'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useQuery } from '@tanstack/react-query'
 import { FormProvider, useForm } from 'react-hook-form'
 
-import { StoreDetailFormValues, storeDetailSchema } from '@/entity/seller-info'
+import {
+  StoreDetailFormValues,
+  UpdateStoreDetailRequest,
+  sellerInfoQueries,
+  storeDetailSchema,
+  useUpdateStoreDetailMutation,
+} from '@/entity/seller-info'
 
 import {
   SELLER_INFO_SUBMIT_DIALOG_CONTENT,
   SellerInfoConfirmDialog,
 } from '../seller-info-confirm-dialog'
+import { sellerInfoToast } from '../seller-info-toast'
 import { StoreContactAddressForm } from '../store-contact-address-form'
 import { StoreProfileForm } from '../store-profile-form'
 
+const EMPTY_DEFAULTS: StoreDetailFormValues = {
+  introduce: '',
+  phoneNumber: '',
+  subPhoneNumber: '',
+  emailLocal: '',
+  emailDomain: '',
+  originAddress: '',
+  originAddressDetail: '',
+}
+
 export function StoreInfoForm() {
   const [isSubmitDialogOpen, setIsSubmitDialogOpen] = useState(false)
+  const [profileImage, setProfileImage] = useState<File | null>(null)
+
+  const { data, isLoading, isError, refetch } = useQuery(
+    sellerInfoQueries.store(),
+  )
+  const { mutate, isPending } = useUpdateStoreDetailMutation()
 
   const methods = useForm<StoreDetailFormValues>({
     resolver: zodResolver(storeDetailSchema),
-    defaultValues: {
-      introduce: '',
-      phoneNumber: '',
-      subPhoneNumber: '',
-      emailLocal: '',
-      emailDomain: '',
-      originAddress: '',
-      originAddressDetail: '',
-    },
+    defaultValues: EMPTY_DEFAULTS,
     mode: 'onChange',
   })
 
+  const { reset } = methods
+
+  useEffect(() => {
+    if (!data) return
+    const { store } = data
+    const [emailLocal = '', emailDomain = ''] = store.email.split('@')
+    reset({
+      introduce: store.introduce ?? '',
+      phoneNumber: store.phoneNumber ?? '',
+      subPhoneNumber: store.subPhoneNumber ?? '',
+      emailLocal,
+      emailDomain,
+      originAddress: store.originAddress ?? '',
+      originAddressDetail: store.originAddressDetail ?? '',
+    })
+  }, [data, reset])
+
+  if (isLoading) {
+    return (
+      <section className="rounded-20 bg-white p-24">
+        <div className="py-40 text-center typo-body-14-r text-gray-500">
+          스토어 정보를 불러오는 중이에요.
+        </div>
+      </section>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <section className="rounded-20 bg-white p-24">
+        <div className="flex flex-col items-center gap-12 py-40">
+          <p className="typo-body-14-r text-gray-500">
+            스토어 정보를 불러오지 못했어요.
+          </p>
+          <Button
+            title="다시 시도"
+            variant="secondary-outlined"
+            onClick={() => refetch()}
+          />
+        </div>
+      </section>
+    )
+  }
+
   const onSubmit = () => {
     setIsSubmitDialogOpen(true)
+  }
+
+  const handleConfirm = () => {
+    const values = methods.getValues()
+    const request: UpdateStoreDetailRequest = {
+      storeName: data.store.name,
+      introduce: values.introduce,
+      phoneNumber: values.phoneNumber,
+      subPhoneNumber: values.subPhoneNumber ?? '',
+      email: `${values.emailLocal}@${values.emailDomain}`,
+      originAddress: values.originAddress,
+      originAddressDetail: values.originAddressDetail,
+    }
+
+    mutate(
+      { request, profileImage },
+      {
+        onSuccess: () => {
+          sellerInfoToast.saveSuccess()
+          setProfileImage(null)
+        },
+        onError: () => {
+          sellerInfoToast.storeInfoSaveError()
+        },
+        onSettled: () => setIsSubmitDialogOpen(false),
+      },
+    )
   }
 
   return (
@@ -41,7 +128,11 @@ export function StoreInfoForm() {
 
         <div className="flex flex-col gap-20 2xl:flex-row">
           <div className="w-full xl:w-[220px] 2xl:shrink-0">
-            <StoreProfileForm />
+            <StoreProfileForm
+              profileImage={profileImage}
+              onProfileImageChange={setProfileImage}
+              initialProfileUrl={data.store.profile}
+            />
           </div>
           <div className="w-full min-w-0 2xl:flex-1">
             <StoreContactAddressForm />
@@ -52,6 +143,7 @@ export function StoreInfoForm() {
           <Button
             title="수정하기"
             className="min-w-[160px]"
+            disabled={isPending}
             onClick={methods.handleSubmit(onSubmit)}
           />
         </div>
@@ -61,7 +153,7 @@ export function StoreInfoForm() {
           title={SELLER_INFO_SUBMIT_DIALOG_CONTENT.title}
           description={SELLER_INFO_SUBMIT_DIALOG_CONTENT.description}
           onOpenChange={setIsSubmitDialogOpen}
-          onConfirm={() => setIsSubmitDialogOpen(false)}
+          onConfirm={handleConfirm}
         />
       </section>
     </FormProvider>

--- a/apps/seller/src/features/seller-info/store-info-form/store-info-form.ui.tsx
+++ b/apps/seller/src/features/seller-info/store-info-form/store-info-form.ui.tsx
@@ -35,9 +35,7 @@ export function StoreInfoForm() {
   const [isSubmitDialogOpen, setIsSubmitDialogOpen] = useState(false)
   const [profileImage, setProfileImage] = useState<File | null>(null)
 
-  const { data, isLoading, isError, refetch } = useQuery(
-    sellerInfoQueries.store(),
-  )
+  const { data } = useQuery(sellerInfoQueries.store())
   const { mutate, isPending } = useUpdateStoreDetailMutation()
 
   const methods = useForm<StoreDetailFormValues>({
@@ -63,32 +61,8 @@ export function StoreInfoForm() {
     })
   }, [data, reset])
 
-  if (isLoading) {
-    return (
-      <section className="rounded-20 bg-white p-24">
-        <div className="py-40 text-center typo-body-14-r text-gray-500">
-          스토어 정보를 불러오는 중이에요.
-        </div>
-      </section>
-    )
-  }
-
-  if (isError || !data) {
-    return (
-      <section className="rounded-20 bg-white p-24">
-        <div className="flex flex-col items-center gap-12 py-40">
-          <p className="typo-body-14-r text-gray-500">
-            스토어 정보를 불러오지 못했어요.
-          </p>
-          <Button
-            title="다시 시도"
-            variant="secondary-outlined"
-            onClick={() => refetch()}
-          />
-        </div>
-      </section>
-    )
-  }
+  // 조회 로딩과 실패는 페이지에서 한 번만 처리한다.
+  if (!data) return null
 
   const onSubmit = () => {
     setIsSubmitDialogOpen(true)

--- a/apps/seller/src/features/seller-info/store-name-form/store-name-form.ui.tsx
+++ b/apps/seller/src/features/seller-info/store-name-form/store-name-form.ui.tsx
@@ -25,9 +25,7 @@ import { sellerInfoToast } from '../seller-info-toast'
 type ConfirmDialogType = 'cancel' | 'submit'
 
 export function StoreNameForm() {
-  const { data, isLoading, isError, refetch } = useQuery({
-    ...sellerInfoQueries.store(),
-  })
+  const { data } = useQuery(sellerInfoQueries.store())
   const { mutate: checkName } = useCheckStoreNameMutation()
   const { mutate: requestChange, isPending: isRequesting } =
     useRequestStoreNameChangeMutation()
@@ -50,28 +48,8 @@ export function StoreNameForm() {
     mode: 'onChange',
   })
 
-  if (isLoading) {
-    return (
-      <div className="py-40 text-center typo-body-14-r text-gray-500">
-        스토어 정보를 불러오는 중이에요.
-      </div>
-    )
-  }
-
-  if (isError || !data) {
-    return (
-      <div className="flex flex-col items-center gap-12 py-40">
-        <p className="typo-body-14-r text-gray-500">
-          스토어 정보를 불러오지 못했어요.
-        </p>
-        <Button
-          title="다시 시도"
-          variant="secondary-outlined"
-          onClick={() => refetch()}
-        />
-      </div>
-    )
-  }
+  // 조회 로딩과 실패는 페이지에서 한 번만 처리한다.
+  if (!data) return null
 
   const { available, store } = data
   const storeName = watch('storeName').trim()

--- a/apps/seller/src/features/seller-info/store-profile-form/store-profile-form.ui.tsx
+++ b/apps/seller/src/features/seller-info/store-profile-form/store-profile-form.ui.tsx
@@ -1,7 +1,5 @@
-import { useState } from 'react'
-
-import { Controller, useFormContext } from 'react-hook-form'
 import { Textarea } from '@dessert/ui'
+import { Controller, useFormContext } from 'react-hook-form'
 
 import { StoreDetailFormValues } from '@/entity/seller-info'
 
@@ -10,9 +8,17 @@ import { StoreProfileImagePreview } from '../store-profile-image-preview'
 const IMG_NOTICE_SIZE = '권장 크기 1000x1000, 최소 160 이상 (1:1 비율)'
 const IMG_NOTICE_FORMAT = 'jpg,jpeg,png 형식 10MB 이하 파일만 업로드 가능해요'
 
-export function StoreProfileForm() {
-  const [profileImageFile, setProfileImageFile] = useState<File | null>(null)
+interface StoreProfileFormProps {
+  profileImage: File | null
+  onProfileImageChange: (file: File | null) => void
+  initialProfileUrl?: string
+}
 
+export function StoreProfileForm({
+  profileImage,
+  onProfileImageChange,
+  initialProfileUrl,
+}: StoreProfileFormProps) {
   const {
     control,
     formState: { errors },
@@ -23,8 +29,9 @@ export function StoreProfileForm() {
       <h2 className="text-[14px] text-gray-800">스토어 프로필</h2>
       <StoreProfileImagePreview
         className="mt-4"
-        file={profileImageFile}
-        onChange={setProfileImageFile}
+        file={profileImage}
+        initialUrl={initialProfileUrl}
+        onChange={onProfileImageChange}
       />
       <div className="text-[10px] font-normal text-gray-500">
         <p>{IMG_NOTICE_SIZE}</p>

--- a/apps/seller/src/features/seller-info/store-profile-image-preview/store-profile-image-preview.ui.tsx
+++ b/apps/seller/src/features/seller-info/store-profile-image-preview/store-profile-image-preview.ui.tsx
@@ -7,12 +7,15 @@ import { cn } from '@/shared/libs/utils'
 interface StoreProfileImagePreviewProps {
   className?: string
   file?: File | null
+  // 수정 화면에서 기존 등록된 프로필 이미지 URL. 새 파일을 고르지 않았을 때만 노출.
+  initialUrl?: string
   onChange: (file: File | null) => void
 }
 
 export function StoreProfileImagePreview({
   className,
   file,
+  initialUrl,
   onChange,
 }: StoreProfileImagePreviewProps) {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -55,6 +58,9 @@ export function StoreProfileImagePreview({
     }
   }, [file])
 
+  // 새로 고른 파일 우선, 없으면 기존 등록된 이미지 URL.
+  const displayUrl = previewUrl || initialUrl || ''
+
   return (
     <div className={cn('flex flex-col gap-8', className)}>
       <input
@@ -65,21 +71,30 @@ export function StoreProfileImagePreview({
         onChange={handleFileChange}
       />
       <div className="relative size-[200px] overflow-hidden rounded-32 border border-gray-100">
-        {previewUrl ? (
+        {displayUrl ? (
           <div className="relative size-full">
-            <img
-              src={previewUrl}
-              alt="스토어 프로필 미리보기"
-              className="size-full object-cover"
-            />
             <button
               type="button"
-              onClick={handleRemove}
-              aria-label="이미지 제거"
-              className="absolute top-12 right-12 flex size-20 cursor-pointer items-center justify-center"
+              onClick={handleUploadAreaClick}
+              aria-label="이미지 변경"
+              className="size-full cursor-pointer"
             >
-              <XIcon className="size-20" />
+              <img
+                src={displayUrl}
+                alt="스토어 프로필 미리보기"
+                className="size-full object-cover"
+              />
             </button>
+            {file && (
+              <button
+                type="button"
+                onClick={handleRemove}
+                aria-label="이미지 제거"
+                className="absolute top-12 right-12 flex size-20 cursor-pointer items-center justify-center"
+              >
+                <XIcon className="size-20" />
+              </button>
+            )}
           </div>
         ) : (
           <button

--- a/apps/seller/src/pages/seller-info/seller-info-page.tsx
+++ b/apps/seller/src/pages/seller-info/seller-info-page.tsx
@@ -1,10 +1,56 @@
+import { Button } from '@dessert/ui'
+import { useQuery } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
+
+import { sellerInfoQueries } from '@/entity/seller-info'
 import {
   StoreAccountInfoForm,
   StoreInfoForm,
   StoreNameForm,
 } from '@/features/seller-info'
+import { extractServerMessage } from '@/shared/utils/extract-server-message'
+
+// 헤더 80px와 본문 상하 여백 80px을 뺀 높이. 조회 상태 화면이 본문 영역을 채우도록 한다.
+const STATE_SECTION_STYLE =
+  'mx-auto flex min-h-[calc(100vh-160px)] max-w-[1100px] items-center justify-center rounded-20 bg-white p-24'
 
 export function SellerInfoPage() {
+  const { data, isLoading, isError, error, refetch } = useQuery(
+    sellerInfoQueries.store(),
+  )
+
+  if (isLoading) {
+    return (
+      <section className={STATE_SECTION_STYLE}>
+        <p className="typo-body-14-r text-gray-500">
+          스토어 정보를 불러오는 중이에요.
+        </p>
+      </section>
+    )
+  }
+
+  if (isError || !data) {
+    // 서버가 사유를 내려준 경우 그대로 노출. 그 외에는 내부 메시지 대신 기본 문구.
+    const serverMessage =
+      extractServerMessage(error) ??
+      (error && !isAxiosError(error) ? error.message : undefined)
+
+    return (
+      <section className={STATE_SECTION_STYLE}>
+        <div className="flex flex-col items-center gap-12">
+          <p className="typo-body-14-r text-gray-500">
+            {serverMessage ?? '스토어 정보를 불러오지 못했어요.'}
+          </p>
+          <Button
+            title="다시 시도"
+            variant="secondary-outlined"
+            onClick={() => refetch()}
+          />
+        </div>
+      </section>
+    )
+  }
+
   return (
     <div className="mx-auto flex max-w-[1100px] min-w-0 flex-col gap-40 overflow-hidden">
       <StoreNameForm />


### PR DESCRIPTION
## 이슈 번호
#272 

## 작업 내용 및 테스트 방법
셀러 정보수정(S06) 화면의 스토어 정보 수정 API 연동 작업입니다.

기존에는 수정하기를 눌러도 확인 다이얼로그만 열리고 실제 저장이 되지 않았는데 이번에 조회부터 저장까지 전체 흐름을 연결했습니다.

### 조회 및 프리필
- 화면 진입 시 등록된 스토어 정보를 조회해 폼에 채웁니다. 이메일은 로컬과 도메인으로 나누어 각 입력칸에 넣습니다.
- 조회 중에는 안내 문구를, 실패 시에는 다시 시도 버튼을 노출하도록 상태를 분기했습니다.
- 조회 실패 시 서버가 사유를 내려주면 그 문구를 그대로 보여줍니다. 예를 들어 스토어를 등록하지 않은 계정으로 진입하면 왜 안 되는지 화면에서 바로 알 수 있습니다. 사유가 없거나 네트워크 오류처럼 사용자에게 보여줄 것이 없는 경우에만 기본 문구를 씁니다.

### 조회 상태 처리 통합
작업 중 정보수정 화면에서 두 가지 문제를 발견해 함께 고쳤습니다.

- 조회가 실패해도 로딩 문구가 한참 유지되고 같은 요청이 반복해서 나갔습니다. 실패 시 자동 재시도가 돌고 있었기 때문인데, 자동 재시도를 끄고 다시 시도 버튼을 눌렀을 때만 재요청하도록 바꿨습니다. 스토어 미등록처럼 재시도해도 결과가 같은 상황에서 불필요한 요청이 사라집니다.
- 스토어명 폼과 스토어 정보 폼이 같은 조회를 각자 처리하고 있어 실패 시 같은 안내가 위아래로 두 번 그려졌습니다. 조회의 로딩과 실패 처리를 페이지 한 곳으로 올려 안내와 다시 시도 버튼이 한 번만 나오도록 정리했습니다. 두 폼은 데이터가 준비되기 전에는 아무것도 그리지 않습니다.

### 저장
- 확인 다이얼로그의 확인을 누르면 실제 수정 요청을 보냅니다. 프로필 이미지는 파일을 새로 고른 경우에만 함께 전송합니다.
- 저장이 진행되는 동안 수정하기 버튼을 비활성화해 중복 요청을 막습니다.
- 성공과 실패에 각각 토스트를 노출하고 성공 시 스토어 정보를 다시 불러와 화면에 반영합니다.

### 프로필 이미지
- 이전에는 새로 고른 파일만 보였으나 이제 기존에 등록된 이미지도 표시됩니다.
- 이미지를 누르면 파일 선택이 열려 바로 교체할 수 있습니다.
- 제거 버튼은 이번에 새로 고른 파일에만 노출됩니다. 기존 등록 이미지는 화면에서 임의로 지울 수 없고 교체만 가능합니다.

### 상세주소 입력
- 기존에는 우편번호를 새로 검색해야만 상세주소를 입력할 수 있었습니다. 수정 화면에서는 이미 주소가 채워져 있으므로 프리필된 주소가 있으면 재검색 없이도 상세주소를 고칠 수 있게 했습니다.

## 테스트 방법
로컬에서 셀러 앱을 띄우고 정보수정 화면에 진입해 아래를 확인했습니다.

1. 진입 시 소개글, 연락처, 보조 연락처, 이메일, 출고지 주소가 서버 값으로 채워지는지
2. 프로필 이미지 영역에 기존 등록 이미지가 보이는지 이미지를 눌러 다른 파일로 교체되는지
3. 상세주소를 우편번호 재검색 없이 수정할 수 있는지
4. 수정하기 후 확인을 누르면 저장되고 성공 토스트가 뜨는지 새로고침 후에도 변경값이 유지되는지
5. 저장 중 버튼이 비활성화되는지
6. 스토어를 등록하지 않은 계정으로 진입했을 때 안내가 한 번만 뜨고, 요청이 반복되지 않는지

## To reviewers
- 스토어명은 이 화면에서 수정할 수 없고 별도 변경 신청 플로우를 따르지만 수정 명세상 필수값이라 조회해온 현재 값을 그대로 다시 보냅니다.
- 수정 요청이 전체 교체 방식이라 소개글과 보조 연락처처럼 비어 있을 수 있는 값도 빈 문자열로 항상 포함해 보냅니다.
- 우편번호가 별도 필드로 내려오지 않고 주소 문자열 안에 포함된 형태입니다. 그래서 수정 화면의 우편번호 입력칸은 프리필할 수 없습니다. 주소를 건드리지 않으면 서버 값이 그대로 왕복되어 문제가 없으나 우편번호를 다시 검색하면 주소 형식이 서버 형식과 달라집니다. 회원가입 등록 플로우와 공통으로 걸린 사안이라 이번 PR 범위에서는 제외했고, 별도로 정리하려 합니다.
- 계좌 정보 조회가 사용하는 경로가 명세서에 적힌 경로와 다릅니다. 동작에는 문제가 없으나 확인이 필요해 보여 남겨둡니다.
- 스토어명 폼은 원래 이번 이슈 범위가 아니지만, 스토어 정보 폼과 같은 조회를 쓰면서 실패 안내를 중복으로 그리던 쪽이라 함께 손댔습니다. 해당 폼에서 제거한 로딩과 실패 화면은 없어진 것이 아니라 페이지로 옮겨간 것입니다.
- 자동 재시도를 끈 설정은 스토어 조회 쿼리 정의에 넣어서 같은 조회를 쓰는 스토어명 폼에도 동일하게 적용됩니다.