### PR TITLE
🐛 Fix : 어드민 페이지 보정 및 셀러 인증/가드 상태 관리 버그 수정

### DIFF
--- a/apps/admin/src/features/store/member-approval/member-approval-table.ui.tsx
+++ b/apps/admin/src/features/store/member-approval/member-approval-table.ui.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Input, Table, getRowSpanForGroup, toast } from '@dessert/ui'
 import { keepPreviousData } from '@tanstack/react-query'
@@ -152,6 +152,7 @@ export const MemberApprovalTable = () => {
     [data?.adminSellerApplicationList],
   )
   const totalPages = data?.totalPages ?? 0
+  const shouldSkipSelectionResetRef = useRef(false)
 
   const setCurrentPage = useCallback(
     (page: number) => {
@@ -171,11 +172,17 @@ export const MemberApprovalTable = () => {
     const maxPage = Math.max(totalPages, 1)
 
     if (currentPage > maxPage) {
+      shouldSkipSelectionResetRef.current = true
       setCurrentPage(maxPage)
     }
   }, [currentPage, totalPages, setCurrentPage])
 
   useEffect(() => {
+    if (shouldSkipSelectionResetRef.current) {
+      shouldSkipSelectionResetRef.current = false
+      return
+    }
+
     setSelectedIds([])
     reset({ approvals: {} })
   }, [currentPage, reset])

--- a/apps/admin/src/features/store/member-approval/member-approval-table.ui.tsx
+++ b/apps/admin/src/features/store/member-approval/member-approval-table.ui.tsx
@@ -123,19 +123,22 @@ export const MemberApprovalTable = () => {
     isApproving,
     isDownloadingDocuments,
   } = useMemberApproval({
-    onApprovalSuccess: (result) => {
-      const successIds = new Set(
-        result.successDetails.map((detail) =>
-          String(detail.storeApplicationId),
-        ),
-      )
+    onApproved: (failedIds) => {
+      setSelectedIds(failedIds)
 
-      setSelectedIds((prev) => prev.filter((id) => !successIds.has(id)))
-      successIds.forEach((id) => unregister(`approvals.${id}`))
-
-      if (result.failDetails.length === 0) {
+      if (failedIds.length === 0) {
         reset({ approvals: {} })
+        return
       }
+
+      const failedIdSet = new Set(failedIds)
+      const approvals = getValues('approvals')
+
+      Object.keys(approvals).forEach((id) => {
+        if (!failedIdSet.has(id)) {
+          unregister(`approvals.${id}`)
+        }
+      })
     },
   })
 

--- a/apps/admin/src/features/store/member-approval/member-approval-table.ui.tsx
+++ b/apps/admin/src/features/store/member-approval/member-approval-table.ui.tsx
@@ -148,25 +148,29 @@ export const MemberApprovalTable = () => {
     () => data?.adminSellerApplicationList.map(toTableRow) ?? [],
     [data?.adminSellerApplicationList],
   )
+  const totalPages = data?.totalPages ?? 0
 
-  useEffect(() => {
-    const totalPages = data?.totalPages
-
-    if (totalPages !== undefined) {
-      const maxPage = Math.max(totalPages, 1)
-
-      if (currentPage <= maxPage) return
-
+  const setCurrentPage = useCallback(
+    (page: number) => {
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev)
-          next.set('page', String(maxPage))
+          next.set('page', String(page))
           return next
         },
         { replace: true },
       )
+    },
+    [setSearchParams],
+  )
+
+  useEffect(() => {
+    const maxPage = Math.max(totalPages, 1)
+
+    if (currentPage > maxPage) {
+      setCurrentPage(maxPage)
     }
-  }, [currentPage, data?.totalPages, setSearchParams])
+  }, [currentPage, totalPages, setCurrentPage])
 
   useEffect(() => {
     setSelectedIds([])
@@ -321,7 +325,7 @@ export const MemberApprovalTable = () => {
           totalCount={totalCount}
           selectedCount={selectedCount}
           currentPage={currentPage}
-          totalPages={data?.totalPages || 1}
+          totalPages={Math.max(totalPages, 1)}
           isTableActionDisabled={isTableActionDisabled}
           isDownloadDisabled={isDownloadDisabled}
           onPageChange={handlePageChange}

--- a/apps/admin/src/features/store/member-approval/member-approval.hook.ts
+++ b/apps/admin/src/features/store/member-approval/member-approval.hook.ts
@@ -2,10 +2,7 @@ import { useRef } from 'react'
 
 import { toast } from '@dessert/ui'
 
-import {
-  AdminSellerApplicationApproveListResult,
-  StoreApplicationApprove,
-} from '@/entity/store/member-approval'
+import { StoreApplicationApprove } from '@/entity/store/member-approval'
 
 import {
   useApproveMemberApplicationsMutation,
@@ -13,11 +10,11 @@ import {
 } from './member-approval.mutation'
 
 interface UseMemberApprovalArgs {
-  onApprovalSuccess?: (result: AdminSellerApplicationApproveListResult) => void
+  onApproved?: (failedIds: string[]) => void
 }
 
 export const useMemberApproval = ({
-  onApprovalSuccess,
+  onApproved,
 }: UseMemberApprovalArgs = {}) => {
   const { mutateAsync: approveApplications, isPending: isApproving } =
     useApproveMemberApplicationsMutation()
@@ -38,8 +35,11 @@ export const useMemberApproval = ({
 
     try {
       const result = await approveApplications(payload)
+      const failedIds = result.failDetails.map((detail) =>
+        String(detail.storeApplicationId),
+      )
 
-      onApprovalSuccess?.(result)
+      onApproved?.(failedIds)
     } catch {
       // 에러 토스트는 mutation onError에서 처리합니다.
     } finally {

--- a/apps/seller/src/entity/auth/auth-store.ts
+++ b/apps/seller/src/entity/auth/auth-store.ts
@@ -41,8 +41,16 @@ export const useAuthStore = create<AuthState>()(
         sellerId: state.sellerId,
         sellerStatus: state.sellerStatus,
       }),
-      onRehydrateStorage: () => (state) => {
-        state?.setHasHydrated(true)
+      onRehydrateStorage: () => (_state, error) => {
+        if (error) {
+          console.error('Auth store rehydration failed:', error)
+        }
+
+        if (_state) {
+          _state.setHasHydrated(true)
+        } else {
+          useAuthStore.getState().setHasHydrated(true)
+        }
       },
     },
   ),

--- a/apps/seller/src/entity/auth/auth-store.ts
+++ b/apps/seller/src/entity/auth/auth-store.ts
@@ -41,7 +41,7 @@ export const useAuthStore = create<AuthState>()(
         sellerId: state.sellerId,
         sellerStatus: state.sellerStatus,
       }),
-      onRehydrateStorage: () => (_state, error) => {
+      onRehydrateStorage: (initialState) => (_state, error) => {
         if (error) {
           console.error('Auth store rehydration failed:', error)
         }
@@ -49,7 +49,9 @@ export const useAuthStore = create<AuthState>()(
         if (_state) {
           _state.setHasHydrated(true)
         } else {
-          useAuthStore.getState().setHasHydrated(true)
+          queueMicrotask(() => {
+            initialState?.setHasHydrated(true)
+          })
         }
       },
     },

--- a/apps/seller/src/features/auth/status-guard/status-guard.ui.tsx
+++ b/apps/seller/src/features/auth/status-guard/status-guard.ui.tsx
@@ -68,7 +68,17 @@ export function RegisterAccessRoute() {
     return <Navigate to={ROUTES.PRODUCTS.ALL} replace />
   }
 
-  // 승인 대기/거절은 완료 화면만 허용
+  if (sellerStatus === 'NEW') {
+    const isCompletePage = location.pathname === ROUTES.REGISTER.COMPLETE
+    const isAllowedRegisterPath =
+      location.pathname === ROUTES.REGISTER.VERIFICATION ||
+      location.pathname === ROUTES.REGISTER.STORE_INFO
+
+    if (isCompletePage || !isAllowedRegisterPath) {
+      return <Navigate to={ROUTES.REGISTER.VERIFICATION} replace />
+    }
+  }
+
   if (
     (sellerStatus === 'PENDING' || sellerStatus === 'REJECTED') &&
     location.pathname !== ROUTES.REGISTER.COMPLETE

--- a/apps/seller/src/pages/register/complete/complete-page.tsx
+++ b/apps/seller/src/pages/register/complete/complete-page.tsx
@@ -22,6 +22,7 @@ const STATUS_LABEL: Record<StoreApplicationStatus, string> = {
 const CompletePage = () => {
   const navigate = useNavigate()
   const sellerStatus = useAuthStore((s) => s.sellerStatus)
+  const setSellerStatus = useAuthStore((s) => s.setSellerStatus)
   const logout = useAuthStore((s) => s.logout)
   const { data: application, isLoading } = useQuery({
     ...registerQueries.application(),
@@ -40,6 +41,7 @@ const CompletePage = () => {
 
   const handleCta = () => {
     if (status === 'APPROVED') {
+      setSellerStatus('APPROVED')
       navigate(ROUTES.PRODUCTS.ALL, { replace: true })
       return
     }


### PR DESCRIPTION
## 작업 내용
### 1. 어드민 회원 승인 테이블 유효 페이지 자동 보정
* **기존 문제점**: 마지막 페이지의 회원 항목을 전량 승인/삭제하여 전체 페이지 수가 감소하더라도 상태가 기존 번호로 유지되어 빈 테이블 화면이 노출되는 현상이 존재했습니다.
* **개선 내용**: totalPages 변동 시 currentPage > Math.max(totalPages, 1) 조건을 감지하여 유효한 마지막 페이지로 자동 이동하도록 useEffect 보정 로직을 추가했습니다.

### 2. 다중 셀러 승인 시 부분 성공 처리 (재시도 UX 개선)
* **기존 문제점**: 다중 셀러 승인 요청 시 일부만 성공하고 일부가 실패하더라도 전체 선택 상태가 초기화되어, 관리자가 실패 건을 다시 찾아 체크해야 하는 번거로움이 있었습니다.
* **개선 내용**: 부분 성공 시 실패한 셀러 ID만 선택 상태에 남겨두도록 훅 및 UI를 개편하여 관리자가 실패 항목에 대해 즉시 재시도할 수 있도록 개선했습니다.

### 3. Zustand auth-store 재수화 에러 처리 보정
* **기존 문제점**: onRehydrateStorage 실패/오류 경로에서는 post-callback의 state 인자가 undefined로 전달되어 state?.setHasHydrated(true)가 실행되지 못하고, hasHydrated가 false로 남아 보안 가드가 무한 로딩 상태에 갇히는 결함이 있었습니다.
* **개선 내용**: 에러 발생 또는 state가 undefined인 예외 경로에서도 setHasHydrated(true)가 명시적으로 호출되도록 보완하여 무한 로딩을 방지하고 로그인/예외 화면으로 안전하게 폴백되도록 수정했습니다.

### 4. StatusGuard 내 NEW 상태 셀러의 완료 페이지 직접 접근 차단
* **기존 문제점**: 신규 회원이 가입 완료 페이지로 직접 접근 시 가드를 통과하여 엉뚱하게 승인 대기 화면이 노출되고, 해당 화면의 버튼 클릭 시 세션이 파기되는 문제가 있었습니다.
* **개선 내용**: NEW 상태 셀러가 완료 페이지에 진입할 경우 본인 인증/정보 입력 경로로 즉시 리다이렉트되도록 라우팅 가드를 강화했습니다.

### 5. 가입 완료 페이지 내 APPROVED 상태 동기화
* **기존 문제점**: 서버의 신규 신청 상태가 APPROVED임에도 클라이언트 스토어에 PENDING이 남아있어, 대시보드로 이동 시 라우터 가드에 의해 가입 완료 페이지로 다시 튕겨 나오는 가드 핑퐁 버그가 발생했습니다.
* **개선 내용**: 대시보드 이동 CTA 버튼 클릭 시 setSellerStatus('APPROVED')를 먼저 호출하여 클라이언트 상태를 서버 최신 상태와 동기화한 뒤 이동하도록 보완했습니다.

--- 
## 테스트 방법
1. **페이지 보정**: 마지막 페이지의 모든 회원 항목 승인 처리 후, 자동으로 이전 페이지로 스무스하게 이동하는지 확인
2. **부분 성공**: 다중 셀러 선택 후 승인 시 실패건(서버 에러 유도) 발생 시 해당 항목만 체크박스가 남아있는지 확인
3. **Hydration 에러**: LocalStorage 값을 강제로 오염시킨 후 앱 진입 시 무한 로딩에 빠지지 않고 로그인/가드 페이지가 정상 표시되는지 확인
4. **가드 리다이렉트**: NEW 셀러 계정 상태에서 /register/complete URL 직접 입력 시 /register/verification으로 리다이렉트되는지 확인
5. **승인 상태 동기화**: APPROVED 승인 셀러 계정으로 가입 완료 페이지 진입 후 대시보드 버튼 클릭 시 튕김 없이 상품 목록 페이지로 정상 진입하는지 확인