### PR TITLE
🐛 Fix: [admin] 로그인 없이 모든 페이지 접근 가능한 문제 수정 (라우트 가드 추가)

### DIFF
--- a/apps/admin/src/app/main.tsx
+++ b/apps/admin/src/app/main.tsx
@@ -4,6 +4,7 @@ import '@/styles/index.css'
 import ReactDOM from 'react-dom/client'
 import { Navigate, createBrowserRouter } from 'react-router-dom'
 
+import { GuestOnlyRoute, ProtectedRoute } from '@/features/auth'
 import AuthPage from '@/pages/auth/auth-page'
 import { NoticePage } from '@/pages/home-page/notice'
 import { AllProductPage } from '@/pages/product/all-product'
@@ -18,42 +19,52 @@ import FixedLayout from './fixed-layout'
 
 const router = createBrowserRouter([
   {
-    path: ROUTES.HOME,
-    element: <FixedLayout />,
+    element: <ProtectedRoute />,
     children: [
       {
-        index: true,
-        element: <Navigate to={ROUTES.STORE.MEMBER_APPROVAL} replace />,
-      },
-      {
-        path: ROUTES.STORE.MEMBER_APPROVAL,
-        element: <MemberApprovalPage />,
-      },
-      {
-        path: ROUTES.STORE.NAME_CHANGE_APPROVAL,
-        element: <NameChangeApprovalPage />,
-      },
-      {
-        path: ROUTES.STORE.REGISTRATION,
-        element: <StoreRegistrationPage />,
-      },
-      {
-        path: ROUTES.PRODUCTS.UPLOAD_APPROVAL,
-        element: <UploadApprovalPage />,
-      },
-      {
-        path: ROUTES.PRODUCTS.ALL,
-        element: <AllProductPage />,
-      },
-      {
-        path: ROUTES.HOMEPAGE.NOTICE,
-        element: <NoticePage />,
+        path: ROUTES.HOME,
+        element: <FixedLayout />,
+        children: [
+          {
+            index: true,
+            element: <Navigate to={ROUTES.STORE.MEMBER_APPROVAL} replace />,
+          },
+          {
+            path: ROUTES.STORE.MEMBER_APPROVAL,
+            element: <MemberApprovalPage />,
+          },
+          {
+            path: ROUTES.STORE.NAME_CHANGE_APPROVAL,
+            element: <NameChangeApprovalPage />,
+          },
+          {
+            path: ROUTES.STORE.REGISTRATION,
+            element: <StoreRegistrationPage />,
+          },
+          {
+            path: ROUTES.PRODUCTS.UPLOAD_APPROVAL,
+            element: <UploadApprovalPage />,
+          },
+          {
+            path: ROUTES.PRODUCTS.ALL,
+            element: <AllProductPage />,
+          },
+          {
+            path: ROUTES.HOMEPAGE.NOTICE,
+            element: <NoticePage />,
+          },
+        ],
       },
     ],
   },
   {
-    path: ROUTES.LOGIN,
-    element: <AuthPage />,
+    element: <GuestOnlyRoute />,
+    children: [
+      {
+        path: ROUTES.LOGIN,
+        element: <AuthPage />,
+      },
+    ],
   },
 ])
 

--- a/apps/admin/src/features/auth/auth-guard.ui.tsx
+++ b/apps/admin/src/features/auth/auth-guard.ui.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react'
+
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
+
+import { useAuthStore } from '@/entity/auth'
+import { ROUTES, TOKEN_COOKIE_KEYS } from '@/shared/constant'
+import { getCookie } from '@/shared/utils'
+
+export interface RedirectState {
+  from?: string
+}
+
+const hasValidSession = (isLoggedIn: boolean) =>
+  isLoggedIn && Boolean(getCookie(TOKEN_COOKIE_KEYS.ACCESS))
+
+/** 스토어에는 로그인 상태로 남아 있지만 토큰이 사라진 경우 정리 */
+const useClearStaleSession = (isLoggedIn: boolean) => {
+  const logout = useAuthStore((state) => state.logout)
+
+  useEffect(() => {
+    if (isLoggedIn && !getCookie(TOKEN_COOKIE_KEYS.ACCESS)) {
+      logout()
+    }
+  }, [isLoggedIn, logout])
+}
+
+/** 관리자 화면 - 로그인하지 않았다면 로그인 화면으로 이동 */
+export const ProtectedRoute = () => {
+  const location = useLocation()
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
+
+  useClearStaleSession(isLoggedIn)
+
+  if (!hasValidSession(isLoggedIn)) {
+    const state: RedirectState = {
+      from: `${location.pathname}${location.search}`,
+    }
+    return <Navigate to={ROUTES.LOGIN} replace state={state} />
+  }
+
+  return <Outlet />
+}
+
+/** 로그인 화면 - 이미 로그인했다면 관리자 화면으로 이동 */
+export const GuestOnlyRoute = () => {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
+
+  useClearStaleSession(isLoggedIn)
+
+  if (hasValidSession(isLoggedIn)) {
+    return <Navigate to={ROUTES.HOME} replace />
+  }
+
+  return <Outlet />
+}

--- a/apps/admin/src/features/auth/index.ts
+++ b/apps/admin/src/features/auth/index.ts
@@ -1,3 +1,5 @@
+export { GuestOnlyRoute, ProtectedRoute } from './auth-guard.ui'
+export type { RedirectState } from './auth-guard.ui'
 export { LoginFooter } from './login-footer.ui'
 export { AuthLoginImage } from './login-image.ui'
 export { useAdminLoginMutation } from './login.mutation'

--- a/apps/admin/src/features/auth/login-form.hook.ts
+++ b/apps/admin/src/features/auth/login-form.hook.ts
@@ -1,13 +1,18 @@
 import { toast } from '@dessert/ui'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import { ROUTES } from '@/shared/constant'
 
 import { useAdminLoginMutation } from './login.mutation'
 import { LoginFormValues, loginSchema } from './login.schema'
 
+import type { RedirectState } from './auth-guard.ui'
+
 export const useLoginForm = () => {
   const navigate = useNavigate()
+  const location = useLocation()
   const {
     register,
     handleSubmit,
@@ -23,7 +28,8 @@ export const useLoginForm = () => {
     mutate(data, {
       onSuccess: () => {
         toast.success('로그인 성공했어요')
-        navigate('/', { replace: true })
+        const { from } = (location.state ?? {}) as RedirectState
+        navigate(from ?? ROUTES.HOME, { replace: true })
       },
       onError: () => {
         toast.error('로그인 정보를 확인하세요', '아이디/비밀번호를 확인하세요')

--- a/apps/admin/src/features/auth/logout.hook.ts
+++ b/apps/admin/src/features/auth/logout.hook.ts
@@ -1,6 +1,8 @@
 import { toast } from '@dessert/ui'
 import { useNavigate } from 'react-router-dom'
 
+import { ROUTES } from '@/shared/constant'
+
 import { useAdminLogoutMutation } from './logout.mutation'
 
 export const useLogout = () => {
@@ -11,10 +13,12 @@ export const useLogout = () => {
     mutate(undefined, {
       onSuccess: () => {
         toast.success('로그아웃 되었어요')
-        navigate('/login', { replace: true })
       },
       onError: () => {
-        toast.error('로그아웃 실패', '다시 시도해주세요')
+        toast.error('로그아웃 처리 중 문제가 생겼어요', '다시 로그인해 주세요')
+      },
+      onSettled: () => {
+        navigate(ROUTES.LOGIN, { replace: true })
       },
     })
   }

--- a/apps/admin/src/features/auth/logout.mutation.ts
+++ b/apps/admin/src/features/auth/logout.mutation.ts
@@ -8,6 +8,6 @@ export const useAdminLogoutMutation = () => {
   return useMutation({
     mutationKey: authKeys.all,
     mutationFn: adminLogout,
-    onSuccess: logout,
+    onSettled: logout,
   })
 }

--- a/apps/admin/src/shared/libs/test/msw/handlers/auth.ts
+++ b/apps/admin/src/shared/libs/test/msw/handlers/auth.ts
@@ -3,14 +3,24 @@ import { HttpResponse, http } from 'msw'
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'
 
 export const authHandlers = [
-  http.post(`${BASE_URL}/api/v1/admins/login`, () => {
+  http.post(`${BASE_URL}/api/v1/admin/login`, () => {
     return HttpResponse.json({
-      accessToken: 'mock-access-token',
-      refreshToken: 'mock-refresh-token',
+      success: true,
+      code: 200,
+      message: 'OK',
+      fieldErrors: [],
+      result: {
+        accessToken: 'mock-access-token',
+        refreshToken: 'mock-refresh-token',
+      },
     })
   }),
 
-  http.post(`${BASE_URL}/api/v1/admins/logout`, () => {
-    return new HttpResponse(null, { status: 204 })
+  http.post(`${BASE_URL}/api/v1/admin/logout`, () => {
+    return HttpResponse.json({
+      success: true,
+      code: 200,
+      message: 'OK',
+    })
   }),
 ]

--- a/apps/admin/src/shared/utils/axios.ts
+++ b/apps/admin/src/shared/utils/axios.ts
@@ -48,9 +48,9 @@ export const setupAuthResponseInterceptor = (
           error.config?.unauthorizedPolicy ?? 'redirect'
 
         // 로그인 요청의 401은 무시 (onError에서 처리)
+        // 세션만 정리하면 라우트 가드가 로그인 화면으로 이동시킨다
         if (!isLoginRequest && unauthorizedPolicy === 'redirect') {
           onUnauthorized()
-          window.location.href = '/login'
         }
       }
       return Promise.reject(error)


### PR DESCRIPTION
## 이슈 번호
#286

## 작업 내용 및 테스트 방법
### 작업 내용
admin 앱에 라우트 가드가 없어 로그인하지 않은 상태로 주소를 직접 입력하면 모든 관리 페이지가 그대로 열렸습니다. 인증 스토어와 쿠키 동기화는 이미 구현되어 있었지만 그 값을 읽어 접근을 막는 곳이 없어 사실상 쓰이지 않는 상태였습니다. 로그인 화면으로 되돌리는 유일한 경로가 응답 인터셉터의 401 처리뿐이라, API를 호출하지 않는 화면에서는 계속 머무를 수 있었습니다.

- 관리자 화면 전체에 인증 가드를 적용해, 로그인하지 않았으면 로그인 화면으로 이동하도록 했습니다.
- 로그인 화면에는 게스트 전용 가드를 적용해, 이미 로그인한 상태면 홈으로 이동하도록 했습니다.
- 세션 유효성을 인증 스토어의 상태와 실제 액세스 토큰의 존재 여부를 함께 확인하도록 하고, 둘이 어긋나면 세션을 정리합니다.
- 가드에 막힌 경로를 보존해, 로그인 성공 후 원래 가려던 화면으로 돌아가도록 했습니다. 기존에는 항상 홈으로 이동했습니다.
- 로그아웃 요청이 실패해도 클라이언트의 토큰과 로그인 상태는 정리되도록 바꿨습니다. 기존에는 실패 시 토큰이 남아 로그아웃되지 않은 상태로 머물렀습니다.
- 인증 만료 응답 처리에서 화면 전체를 새로 불러오던 방식을 걷어내고, 세션 정리 후 가드가 이동을 맡도록 통일했습니다.
- 테스트용 인증 목의 요청 경로와 응답 형태가 실제 API와 달라 어떤 요청도 잡지 못하던 문제를 함께 고쳤습니다.

부팅 시점의 깜빡임은 인증 상태가 확정되기 전까지 렌더를 막는 기존 처리가 이미 있어 그대로 활용했습니다.

이번 PR은 화면 접근 통제까지입니다. 토큰 저장 방식과 리프레시 재발급 처리는 백엔드 협의가 필요해 이슈 #286의 후속 단계로 남겨둡니다.

### 테스트 방법
1. 미인증 접근 차단: 로그아웃 상태에서 회원가입 승인, 스토어명 변경 승인, 스토어 등록, 상품 승인, 전체 상품, 공지 각 경로를 주소창에 직접 입력해 로그인 화면으로 이동하는지 확인
2. 원래 경로 복귀: 로그아웃 상태에서 스토어 등록 경로로 진입해 로그인 화면으로 밀린 뒤, 로그인에 성공하면 홈이 아니라 스토어 등록 화면으로 돌아오는지 확인
3. 로그인 상태의 로그인 화면 접근: 로그인한 상태에서 로그인 경로로 진입 시 홈으로 이동하는지 확인
4. 세션 정리: 개발자 도구에서 액세스 토큰 쿠키를 삭제한 뒤 화면을 이동하면 로그인 화면으로 밀리는지 확인
5. 로그아웃: 좌측 메뉴에서 로그아웃 시 로그인 화면으로 이동하고, 이후 관리 경로로 되돌아갈 수 없는지 확인

## To reviewers
인증 만료 응답 처리에서 로그인 경로로 강제 이동시키던 코드를 상수로 교체하는 대신 제거했습니다. 세션만 정리하면 가드가 이동을 처리하기 때문입니다. 전체 새로고침이 사라져 라우터 상태와 캐시가 유지되고 이동 경로가 한 곳으로 모입니다. 이슈에는 상수 교체로 적어둔 항목이라 방향을 바꾼 점 알려드립니다.

이 가드는 화면 접근 통제이지 데이터 보호가 아닙니다. 쿠키에 임의의 값을 넣으면 화면 자체는 열리지만 API가 인증 오류를 돌려주어 곧바로 로그인 화면으로 되돌아갑니다. 실제 보호는 서버 인증이 담당합니다.