### PR TITLE
✨ Feat: 상품 관리 API 연동 및 데이터 바인딩

### DIFF
--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -10,7 +10,7 @@ export default mergeConfig(baseViteConfig, {
 
   // 포트지정
   server: {
-    port: 6078,
+    port: 3000,
   },
 
   resolve: {

--- a/apps/seller/src/entity/products/create/create-form/product-form.type.ts
+++ b/apps/seller/src/entity/products/create/create-form/product-form.type.ts
@@ -1,9 +1,11 @@
 import { ProductInfoNoticeKey } from '../create-disclosure/product-disclosure.constant'
+import type { ProductionStartTimeType } from '../create-info/production-time.constants'
 
 export type ProductFormInput = {
   productName: string
   isFresh: boolean
-  productionTime: string
+  /** 백엔드 Enum 키 (예: T_03_04). 미선택 시 빈 문자열 */
+  productionTime: ProductionStartTimeType | ''
   price: number | null
   discountAmount: number | null
   discountType: 'won' | 'percentage'

--- a/apps/seller/src/entity/products/create/create-info/production-time.constants.ts
+++ b/apps/seller/src/entity/products/create/create-info/production-time.constants.ts
@@ -1,22 +1,59 @@
-export const productionTimes = [
-  {
-    label: '03:00~04:00',
-    value: '03:00~04:00',
-  },
-  {
-    label: '04:00~05:00',
-    value: '04:00~05:00',
-  },
-  {
-    label: '05:00~06:00',
-    value: '05:00~06:00',
-  },
-  {
-    label: '06:00~07:00',
-    value: '06:00~07:00',
-  },
-  {
-    label: '07:00~08:00',
-    value: '07:00~08:00',
-  },
-]
+export const PRODUCTION_START_TIME_OPTIONS = [
+  { value: 'T_00_01', label: '00:00 ~ 01:00' },
+  { value: 'T_01_02', label: '01:00 ~ 02:00' },
+  { value: 'T_02_03', label: '02:00 ~ 03:00' },
+  { value: 'T_03_04', label: '03:00 ~ 04:00' },
+  { value: 'T_04_05', label: '04:00 ~ 05:00' },
+  { value: 'T_05_06', label: '05:00 ~ 06:00' },
+  { value: 'T_06_07', label: '06:00 ~ 07:00' },
+  { value: 'T_07_08', label: '07:00 ~ 08:00' },
+  { value: 'T_08_09', label: '08:00 ~ 09:00' },
+  { value: 'T_09_10', label: '09:00 ~ 10:00' },
+  { value: 'T_10_11', label: '10:00 ~ 11:00' },
+  { value: 'T_11_12', label: '11:00 ~ 12:00' },
+  { value: 'T_12_13', label: '12:00 ~ 13:00' },
+  { value: 'T_13_14', label: '13:00 ~ 14:00' },
+  { value: 'T_14_15', label: '14:00 ~ 15:00' },
+  { value: 'T_15_16', label: '15:00 ~ 16:00' },
+  { value: 'T_16_17', label: '16:00 ~ 17:00' },
+  { value: 'T_17_18', label: '17:00 ~ 18:00' },
+  { value: 'T_18_19', label: '18:00 ~ 19:00' },
+  { value: 'T_19_20', label: '19:00 ~ 20:00' },
+  { value: 'T_20_21', label: '20:00 ~ 21:00' },
+  { value: 'T_21_22', label: '21:00 ~ 22:00' },
+  { value: 'T_22_23', label: '22:00 ~ 23:00' },
+  { value: 'T_23_00', label: '23:00 ~ 00:00' },
+] as const
+
+export type ProductionStartTimeType =
+  (typeof PRODUCTION_START_TIME_OPTIONS)[number]['value']
+
+/** Dropdown options (label 표시, value는 백엔드 Enum 키) */
+export const productionTimes = PRODUCTION_START_TIME_OPTIONS.map((option) => ({
+  label: option.label,
+  value: option.value,
+}))
+
+const PRODUCTION_START_TIME_SET = new Set<string>(
+  PRODUCTION_START_TIME_OPTIONS.map((option) => option.value),
+)
+
+/** GET 응답 Enum 키를 폼 초기값으로 안전하게 바인딩 */
+export function toProductionStartTimeFormValue(
+  value: string | null | undefined,
+): ProductionStartTimeType | '' {
+  if (!value) return ''
+  return PRODUCTION_START_TIME_SET.has(value)
+    ? (value as ProductionStartTimeType)
+    : ''
+}
+
+export function getProductionStartTimeLabel(
+  value: string | null | undefined,
+): string {
+  if (!value) return ''
+  return (
+    PRODUCTION_START_TIME_OPTIONS.find((option) => option.value === value)
+      ?.label ?? value
+  )
+}

--- a/apps/seller/src/entity/products/create/create.api.ts
+++ b/apps/seller/src/entity/products/create/create.api.ts
@@ -6,21 +6,79 @@ import {
   StoreInfo,
 } from './create.type'
 
+function unwrap<T>(data: ApiResponse<T>, fallback: string): T {
+  if (!data.success || data.result == null) {
+    throw new Error(data.message ?? fallback)
+  }
+  return data.result
+}
+
 // storeId 조회
 export const getMyStore = async () => {
   const response = await client.get<ApiResponse<{ store: StoreInfo }>>(
     '/api/v1/seller/stores',
   )
-  return response.data.result.store
+  return unwrap(response.data, '스토어 정보 조회에 실패했습니다.').store
 }
 
+/**
+ * POST /api/v1/seller/boards
+ * FormData + @ModelAttribute. Content-Type은 지정하지 않음(interceptor가 기본 JSON 제거).
+ */
 export const createProductBoard = async (formData: FormData) => {
-  // FormData 전달 시 Content-Type을 수동 지정하지 않습니다.
-  // Axios가 boundary를 포함한 multipart/form-data 헤더를 자동으로 설정합니다.
   const response = await client.post<ApiResponse<CreateProductBoardResult>>(
     '/api/v1/seller/boards',
     formData,
   )
+
+  if (!response.data.success) {
+    throw new Error(response.data.message ?? '상품 등록에 실패했습니다.')
+  }
+
+  return response.data
+}
+
+/**
+ * PUT /api/v1/seller/boards/{boardId}
+ * FormData + @ModelAttribute. storeId 미포함. Content-Type 미지정.
+ */
+export const updateProductBoard = async (
+  boardId: number,
+  formData: FormData,
+) => {
+  const response = await client.put<ApiResponse<CreateProductBoardResult>>(
+    `/api/v1/seller/boards/${boardId}`,
+    formData,
+  )
+
+  if (!response.data.success) {
+    throw new Error(response.data.message ?? '상품 수정에 실패했습니다.')
+  }
+
+  return response.data
+}
+
+/**
+ * POST /api/v1/seller/boards/delete-boards?storeId={storeId}
+ * JSON body: { boardIds: number[] }
+ */
+export const deleteProductBoards = async (
+  storeId: number,
+  boardIds: number[],
+) => {
+  const response = await client.post<ApiResponse<unknown>>(
+    '/api/v1/seller/boards/delete-boards',
+    { boardIds },
+    {
+      params: { storeId },
+      headers: { 'Content-Type': 'application/json' },
+    },
+  )
+
+  if (!response.data.success) {
+    throw new Error(response.data.message ?? '상품 삭제에 실패했습니다.')
+  }
+
   return response.data
 }
 

--- a/apps/seller/src/entity/products/create/create.query.ts
+++ b/apps/seller/src/entity/products/create/create.query.ts
@@ -1,9 +1,18 @@
 import { queryOptions } from '@tanstack/react-query'
 
+import { getProductBoards } from '../product/product-board.api'
+import type { ProductBoardFilters } from '../product/product-board.type'
+
 import { getMyStore } from './create.api'
 
 export const productQueries = {
-  all: () => ['products'] as const,
+  all: () => ['seller-product-boards'] as const,
+  lists: () => [...productQueries.all(), 'list'] as const,
+  list: (filters: ProductBoardFilters) =>
+    queryOptions({
+      queryKey: [...productQueries.lists(), filters],
+      queryFn: () => getProductBoards(filters),
+    }),
   myStore: () =>
     queryOptions({
       queryKey: [...productQueries.all(), 'myStore'],

--- a/apps/seller/src/entity/products/create/create.type.ts
+++ b/apps/seller/src/entity/products/create/create.type.ts
@@ -3,7 +3,28 @@ export interface CreateProductRequest {
   storeId: number
   title: string
   isFresh: boolean
-  productionStartAt: string
+  /** 백엔드 Enum 상수명 (예: T_03_04) */
+  productionStartTime: string
+  price: number
+  discountType: 'AMOUNT' | 'RATE'
+  discountValue: number
+  deliveryCondition: string
+  deliveryCompany: string
+  deliveryFee: number
+  freeShippingConditions: number
+  products: ProductOptionRequest[]
+  boardDetailRequest: {
+    content: string
+  }
+  productInfoNoticeRequest: Record<string, string>
+}
+
+/** 수정 요청 — storeId 없음, 기존 옵션은 productId 포함 */
+export interface UpdateProductRequest {
+  title: string
+  isFresh: boolean
+  /** 백엔드 Enum 상수명 (예: T_03_04) */
+  productionStartTime: string
   price: number
   discountType: 'AMOUNT' | 'RATE'
   discountValue: number
@@ -19,6 +40,8 @@ export interface CreateProductRequest {
 }
 
 export interface ProductOptionRequest {
+  /** 기존 옵션 수정 시 필수, 신규 옵션은 omit/null */
+  productId?: number | null
   title: string
   category: string
   plusPriceWithBoardPrice: number
@@ -48,6 +71,11 @@ export interface ProductOptionRequest {
     fat: number
     calories: number
   } | null
+}
+
+export interface DeleteProductBoardsRequest {
+  storeId: number
+  boardIds: number[]
 }
 
 // API 응답 타입

--- a/apps/seller/src/entity/products/create/index.ts
+++ b/apps/seller/src/entity/products/create/index.ts
@@ -2,11 +2,15 @@ export {
   getMyStore,
   createProductBoard,
   createProduct,
+  updateProductBoard,
+  deleteProductBoards,
 } from './create.api'
 export { productQueries } from './create.query'
 export type {
   CreateProductRequest,
+  UpdateProductRequest,
   ProductOptionRequest,
+  DeleteProductBoardsRequest,
   CreateProductBoardResult,
   StoreInfo,
   ApiResponse,

--- a/apps/seller/src/entity/products/index.ts
+++ b/apps/seller/src/entity/products/index.ts
@@ -21,12 +21,41 @@ export {
   getMyStore,
   createProductBoard,
   createProduct,
+  updateProductBoard,
+  deleteProductBoards,
   productQueries,
 } from './create'
 export type {
   CreateProductRequest,
+  UpdateProductRequest,
   ProductOptionRequest,
+  DeleteProductBoardsRequest,
   CreateProductBoardResult,
   StoreInfo,
   ApiResponse,
 } from './create'
+
+export { getProductBoards } from './product/product-board.api'
+export { mapProductBoardItemToProductType } from './product/product-board.mapper'
+export {
+  PRODUCT_BOARD_SORT_OPTIONS,
+  DEFAULT_PRODUCT_BOARD_SORT,
+  toProductBoardSortType,
+} from './product/product-board-sort.constants'
+export type { ProductBoardSortType } from './product/product-board-sort.constants'
+export type {
+  ProductBoardItem,
+  ProductBoardInventoryStatus,
+  ProductBoardSaleStatus,
+  TabCounts,
+  ProductBoardsPage,
+  GetProductBoardsResponse,
+  GetProductBoardsResult,
+  ProductBoardFilters,
+  ProductBoardListResponse,
+  ProductBoardStatus,
+  ProductBoardSort,
+  ProductBoardSortBy,
+} from './product/product-board.type'
+export { EMPTY_TAB_COUNTS } from './product/product-board.type'
+export type { ProductType } from './product/product.type'

--- a/apps/seller/src/entity/products/product/product-board-sort.constants.ts
+++ b/apps/seller/src/entity/products/product/product-board-sort.constants.ts
@@ -1,0 +1,24 @@
+export const PRODUCT_BOARD_SORT_OPTIONS = [
+  { value: 'LATEST', label: '최신순' },
+  { value: 'OLDEST', label: '오래된 순' },
+  { value: 'NAME', label: '상품명 순' },
+] as const
+
+export type ProductBoardSortType =
+  (typeof PRODUCT_BOARD_SORT_OPTIONS)[number]['value']
+
+export const DEFAULT_PRODUCT_BOARD_SORT: ProductBoardSortType = 'LATEST'
+
+const PRODUCT_BOARD_SORT_SET = new Set<string>(
+  PRODUCT_BOARD_SORT_OPTIONS.map((option) => option.value),
+)
+
+/** API/상태 값을 SortType Enum으로 보정. 유효하지 않으면 LATEST */
+export function toProductBoardSortType(
+  value: string | null | undefined,
+): ProductBoardSortType {
+  if (value && PRODUCT_BOARD_SORT_SET.has(value)) {
+    return value as ProductBoardSortType
+  }
+  return DEFAULT_PRODUCT_BOARD_SORT
+}

--- a/apps/seller/src/entity/products/product/product-board.api.ts
+++ b/apps/seller/src/entity/products/product/product-board.api.ts
@@ -1,0 +1,67 @@
+import type { ApiResponse } from '@/entity/auth/types'
+import { client } from '@/shared/utils/axios'
+
+import {
+  DEFAULT_PRODUCT_BOARD_SORT,
+  toProductBoardSortType,
+} from './product-board-sort.constants'
+import type {
+  GetProductBoardsResult,
+  ProductBoardFilters,
+  ProductBoardListResponse,
+} from './product-board.type'
+import { EMPTY_TAB_COUNTS } from './product-board.type'
+
+function unwrap<T>(data: ApiResponse<T>, fallback: string): T {
+  if (!data.success || data.result == null) {
+    throw new Error(data.message ?? fallback)
+  }
+  return data.result
+}
+
+/** 빈 문자열 / undefined / null 쿼리 파라미터 제거 */
+function toCleanParams(
+  filters: ProductBoardFilters,
+): Record<string, string | number> {
+  const sortBy = filters.sortBy
+    ? toProductBoardSortType(filters.sortBy)
+    : DEFAULT_PRODUCT_BOARD_SORT
+
+  const params: Record<string, string | number | undefined> = {
+    saleStatus:
+      filters.saleStatus === '전체' ? undefined : filters.saleStatus,
+    mainCategory: filters.mainCategory,
+    category: filters.category,
+    keyword: filters.keyword,
+    page: filters.page,
+    size: filters.size,
+    sortBy,
+  }
+
+  return Object.fromEntries(
+    Object.entries(params).filter(
+      ([, value]) => value !== undefined && value !== null && value !== '',
+    ),
+  ) as Record<string, string | number>
+}
+
+export async function getProductBoards(
+  filters: ProductBoardFilters,
+): Promise<ProductBoardListResponse> {
+  const { data } = await client.get<ApiResponse<GetProductBoardsResult>>(
+    '/api/v1/seller/boards',
+    { params: toCleanParams(filters) },
+  )
+
+  const result = unwrap(data, '상품 목록 조회에 실패했습니다.')
+  const boardsPage = result.boards
+
+  return {
+    boards: boardsPage?.content ?? [],
+    page: boardsPage?.page ?? filters.page ?? 0,
+    size: boardsPage?.size ?? filters.size ?? 20,
+    totalElements: boardsPage?.totalElements ?? 0,
+    totalPages: Math.max(1, boardsPage?.totalPages ?? 1),
+    tabCounts: result.tabCounts ?? EMPTY_TAB_COUNTS,
+  }
+}

--- a/apps/seller/src/entity/products/product/product-board.mapper.ts
+++ b/apps/seller/src/entity/products/product/product-board.mapper.ts
@@ -1,0 +1,63 @@
+import type { ProductType } from './product.type'
+import type {
+  ProductBoardInventoryStatus,
+  ProductBoardItem,
+  ProductBoardSaleStatus,
+} from './product-board.type'
+
+const INVENTORY_STATUS_LABEL: Record<ProductBoardInventoryStatus, string> = {
+  IN_STOCK: '재고있음',
+  OUT_OF_STOCK: '재고없음',
+}
+
+const SALE_STATUS_TO_UI: Record<ProductBoardSaleStatus, ProductType['status']> =
+  {
+    ON_SALE: 'onSale',
+    OUT_OF_STOCK: 'soldOut',
+    STOPPED: 'stopSale',
+    PENDING: 'pending',
+    BANNED: 'banned',
+  }
+
+const DELIVERY_TYPE_TO_SHIPPING: Record<
+  string,
+  ProductType['shipping']['type']
+> = {
+  무료: '무료',
+  FREE: '무료',
+  조건부무료: '조건부 무료',
+  '조건부 무료': '조건부 무료',
+  CONDITIONAL_FREE: '조건부 무료',
+  유료: '유료',
+  PAID: '유료',
+}
+
+export function mapProductBoardItemToProductType(
+  item: ProductBoardItem,
+): ProductType {
+  const shippingType =
+    DELIVERY_TYPE_TO_SHIPPING[item.deliveryType] ??
+    (item.deliveryFee === 0
+      ? '무료'
+      : item.freeShippingConditions > 0
+        ? '조건부 무료'
+        : '유료')
+
+  return {
+    id: String(item.boardId),
+    productName: item.title,
+    thumbnailUrl: item.thumbnailUrl,
+    stockStatus:
+      INVENTORY_STATUS_LABEL[item.inventoryStatus] ?? item.inventoryStatus,
+    originPrice: item.price,
+    salePrice: item.discountPrice,
+    shipping: {
+      type: shippingType,
+      price: item.deliveryFee,
+      ...(shippingType === '조건부 무료'
+        ? { minimumPrice: item.freeShippingConditions }
+        : {}),
+    },
+    status: SALE_STATUS_TO_UI[item.saleStatus] ?? 'pending',
+  }
+}

--- a/apps/seller/src/entity/products/product/product-board.type.ts
+++ b/apps/seller/src/entity/products/product/product-board.type.ts
@@ -1,0 +1,97 @@
+import type { ProductBoardSortType } from './product-board-sort.constants'
+
+export type ProductBoardInventoryStatus = 'IN_STOCK' | 'OUT_OF_STOCK'
+
+export type ProductBoardSaleStatus =
+  | 'ON_SALE'
+  | 'OUT_OF_STOCK'
+  | 'STOPPED'
+  | 'PENDING'
+  | 'BANNED'
+
+export interface ProductBoardItem {
+  boardId: number
+  thumbnailUrl: string
+  title: string
+  inventoryStatus: ProductBoardInventoryStatus
+  price: number
+  discountPrice: number
+  discountValue: number
+  deliveryFee: number
+  freeShippingConditions: number
+  deliveryType: string
+  saleStatus: ProductBoardSaleStatus
+}
+
+export interface TabCounts {
+  ON_SALE: number
+  OUT_OF_STOCK: number
+  STOPPED: number
+  PENDING: number
+  BANNED: number
+}
+
+export interface ProductBoardsPage {
+  content: ProductBoardItem[]
+  page: number
+  size: number
+  totalPages: number
+  totalElements: number
+}
+
+export interface GetProductBoardsResult {
+  tabCounts: TabCounts
+  boards: ProductBoardsPage
+}
+
+export interface GetProductBoardsResponse {
+  success: boolean
+  code: number
+  message: string
+  result: GetProductBoardsResult
+}
+
+/** UI/필터 탭용 한글 상태 (쿼리 파라미터) */
+export type ProductBoardStatus =
+  | '전체'
+  | '판매중'
+  | '품절'
+  | '판매중지'
+  | '판매대기'
+  | '판매금지'
+
+export type { ProductBoardSortType }
+
+/** @deprecated ProductBoardSortType 사용 */
+export type ProductBoardSortBy = ProductBoardSortType
+/** @deprecated ProductBoardSortType 사용 */
+export type ProductBoardSort = ProductBoardSortType
+
+export interface ProductBoardFilters {
+  saleStatus: ProductBoardStatus
+  mainCategory?: string
+  category?: string
+  keyword?: string
+  page: number
+  size: number
+  /** 백엔드 SortType Enum: LATEST | OLDEST | NAME */
+  sortBy?: ProductBoardSortType
+}
+
+/** useQuery에 노출하는 정규화 응답 */
+export interface ProductBoardListResponse {
+  boards: ProductBoardItem[]
+  page: number
+  size: number
+  totalElements: number
+  totalPages: number
+  tabCounts: TabCounts
+}
+
+export const EMPTY_TAB_COUNTS: TabCounts = {
+  ON_SALE: 0,
+  OUT_OF_STOCK: 0,
+  STOPPED: 0,
+  PENDING: 0,
+  BANNED: 0,
+}

--- a/apps/seller/src/entity/products/product/product.type.ts
+++ b/apps/seller/src/entity/products/product/product.type.ts
@@ -2,6 +2,7 @@ export type ProductType = {
   id: string
   sellerName?: string
   productName: string
+  thumbnailUrl?: string
   stockStatus: string
   salePrice: number
   originPrice: number

--- a/apps/seller/src/features/products/create/create-draft/use-create-draft.hook.ts
+++ b/apps/seller/src/features/products/create/create-draft/use-create-draft.hook.ts
@@ -1,6 +1,8 @@
 import { toast } from '@dessert/ui'
 import { useFormContext } from 'react-hook-form'
 
+import { toProductionStartTimeFormValue } from '@/entity/products/create/create-info/production-time.constants'
+
 import {
   clearCreateFormPersistence,
   CREATE_PRODUCT_DEFAULT_VALUES,
@@ -28,7 +30,10 @@ export const useCreateDraft = () => {
   const handleRestoreDraft = () => {
     if (!draft) return
     const { productDetail: savedDetail, ...formValues } = draft
-    form.reset(formValues as CreateProductForm)
+    form.reset({
+      ...formValues,
+      productionTime: toProductionStartTimeFormValue(formValues.productionTime),
+    } as CreateProductForm)
     setProductDetail(savedDetail)
   }
 

--- a/apps/seller/src/features/products/create/create-form-info/create-form-info-area.ui.tsx
+++ b/apps/seller/src/features/products/create/create-form-info/create-form-info-area.ui.tsx
@@ -4,7 +4,7 @@ import { Dropdown, Input, Label, Switch } from '@dessert/ui'
 import { Controller } from 'react-hook-form'
 
 import { ProductDiscountType } from '@/entity/products/create/create-info/product-discount-type.constants'
-import { productionTimes } from '@/entity/products/create/create-info/production-time.constants'
+import { PRODUCTION_START_TIME_OPTIONS } from '@/entity/products/create/create-info/production-time.constants'
 
 import { useProductInfoForm } from './use-product-info-form.hook'
 import { InfoTooltip, ProductFinalPrice } from '../create-form'
@@ -104,10 +104,11 @@ export const ProductInfoArea = () => {
         name="productionTime"
         render={({ field }) => (
           <Dropdown
-            options={productionTimes}
+            options={[...PRODUCTION_START_TIME_OPTIONS]}
             value={field.value}
             className="mt-8"
             onSelect={field.onChange}
+            placeholder="상품 제작 시간을 선택해주세요"
           />
         )}
       />

--- a/apps/seller/src/features/products/create/create-form-info/create-info.schema.ts
+++ b/apps/seller/src/features/products/create/create-form-info/create-info.schema.ts
@@ -1,10 +1,21 @@
 import { z } from 'zod'
 
+import { PRODUCTION_START_TIME_OPTIONS } from '@/entity/products/create/create-info/production-time.constants'
+
+const productionStartTimeValues = PRODUCTION_START_TIME_OPTIONS.map(
+  (option) => option.value,
+) as [string, ...string[]]
+
 export const productSchema = z
   .object({
     productName: z.string(),
     isFresh: z.boolean(),
-    productionTime: z.string().min(1, '상품 제작 시간을 선택해주세요'),
+    productionTime: z
+      .string()
+      .min(1, '상품 제작 시간을 선택해주세요')
+      .refine((value) => productionStartTimeValues.includes(value), {
+        message: '유효한 상품 제작 시간을 선택해주세요',
+      }),
     price: z.union([
       z
         .number({ error: '올바른 가격을 입력해주세요' })

--- a/apps/seller/src/features/products/create/create-form/build-product-board-form-data.utils.ts
+++ b/apps/seller/src/features/products/create/create-form/build-product-board-form-data.utils.ts
@@ -4,7 +4,7 @@ import { ProductOptionsType } from '../create-form-options'
 import { CreateProductForm } from './product-create.types'
 import { mapToBackendCategory } from './map-to-backend-category.utils'
 
-/** Spring @ModelAttribute가 읽을 수 있도록 중첩 값을 dot-notation으로 append */
+/** Spring @ModelAttribute — 중첩은 dot, 배열은 bracket index */
 export function appendFormValue(
   formData: FormData,
   key: string,
@@ -46,11 +46,27 @@ export function appendFormValue(
   formData.append(key, String(value))
 }
 
-function mapOptionToRequest(option: ProductOptionsType): ProductOptionRequest {
+function emptyNutritionInfo() {
+  return {
+    totalWeight: 0,
+    servingSize: 0,
+    carbohydrates: 0,
+    sugars: 0,
+    protein: 0,
+    fat: 0,
+    calories: 0,
+  }
+}
+
+export function mapOptionToRequest(
+  option: ProductOptionsType,
+  productId?: number | null,
+): ProductOptionRequest {
   const days = new Set(option.shippingDays)
   const categorySource = option.subCategory || option.mainCategory
 
   return {
+    ...(productId != null ? { productId } : {}),
     title: option.optionName,
     category: mapToBackendCategory(categorySource),
     plusPriceWithBoardPrice: option.additionalPrice ?? 0,
@@ -81,7 +97,7 @@ function mapOptionToRequest(option: ProductOptionsType): ProductOptionRequest {
           fat: option.fat ?? 0,
           calories: option.calories ?? 0,
         }
-      : null,
+      : emptyNutritionInfo(),
   }
 }
 
@@ -94,7 +110,7 @@ export function mapCreateFormToBoardRequest(
     storeId,
     title: data.productName,
     isFresh: data.isFresh,
-    productionStartAt: data.productionTime,
+    productionStartTime: data.productionTime,
     price: data.price ?? 0,
     discountType: data.discountType === 'won' ? 'AMOUNT' : 'RATE',
     discountValue: data.discountAmount ?? 0,
@@ -102,7 +118,7 @@ export function mapCreateFormToBoardRequest(
     deliveryCompany: data.deliveryCompany,
     deliveryFee: data.deliveryFee ?? 0,
     freeShippingConditions: data.deliveryMinFee ?? 0,
-    products: data.options.map(mapOptionToRequest),
+    products: data.options.map((option) => mapOptionToRequest(option)),
     boardDetailRequest: {
       content: productDetail,
     },
@@ -114,12 +130,13 @@ export interface BuildProductBoardFormDataParams {
   data: CreateProductForm
   productDetail: string
   storeId: number
-  /** 에디터에 삽입된 상세 이미지 파일들 */
+  /** 에디터에 삽입된 상세 이미지 (file.name === content data-id) */
   boardDetailImages?: File[]
 }
 
 /**
- * POST /api/v1/seller/boards (multipart/form-data, Spring @ModelAttribute)
+ * POST /api/v1/seller/boards
+ * multipart/form-data + Spring @ModelAttribute (Content-Type 수동 지정 금지)
  */
 export function buildProductBoardFormData({
   data,
@@ -134,16 +151,104 @@ export function buildProductBoardFormData({
   const request = mapCreateFormToBoardRequest(data, productDetail, storeId)
   const formData = new FormData()
 
-  // 스칼라 / 중첩 객체·배열 → dot-notation
+  // storeId 포함 최상위/중첩/리스트 필드를 flatten append
   Object.entries(request).forEach(([key, value]) => {
     appendFormValue(formData, key, value)
   })
 
-  // 파일 파라미터
   formData.append('thumbnailImgFile', data.mainImage, data.mainImage.name)
 
   data.extraImages?.forEach((item) => {
     formData.append('productImgs', item.file, item.file.name)
+  })
+
+  boardDetailImages.forEach((file) => {
+    formData.append('boardDetailImages', file, file.name)
+  })
+
+  return formData
+}
+
+export interface BuildUpdateProductBoardFormDataParams {
+  data: CreateProductForm
+  productDetail: string
+  /** 옵션 index → 기존 productId (신규 옵션은 없음) */
+  productIdsByOptionIndex?: Array<number | null | undefined>
+  boardDetailImages?: File[]
+  existingThumbnailUrl?: string
+  existingSubImageUrls?: string[]
+  newSubImageFiles?: File[]
+}
+
+/**
+ * PUT /api/v1/seller/boards/{boardId}
+ * storeId 미포함. 이미지 유지/교체 필드 지원.
+ */
+export function buildUpdateProductBoardFormData({
+  data,
+  productDetail,
+  productIdsByOptionIndex = [],
+  boardDetailImages = [],
+  existingThumbnailUrl,
+  existingSubImageUrls = [],
+  newSubImageFiles = [],
+}: BuildUpdateProductBoardFormDataParams): FormData {
+  const formData = new FormData()
+
+  appendFormValue(formData, 'title', data.productName)
+  appendFormValue(formData, 'isFresh', data.isFresh)
+  appendFormValue(formData, 'productionStartTime', data.productionTime)
+  appendFormValue(formData, 'price', data.price ?? 0)
+  appendFormValue(
+    formData,
+    'discountType',
+    data.discountType === 'won' ? 'AMOUNT' : 'RATE',
+  )
+  appendFormValue(formData, 'discountValue', data.discountAmount ?? 0)
+  appendFormValue(formData, 'deliveryCondition', data.deliveryTerms)
+  appendFormValue(formData, 'deliveryCompany', data.deliveryCompany)
+  appendFormValue(formData, 'deliveryFee', data.deliveryFee ?? 0)
+  appendFormValue(
+    formData,
+    'freeShippingConditions',
+    data.deliveryMinFee ?? 0,
+  )
+  appendFormValue(formData, 'boardDetailRequest.content', productDetail)
+  appendFormValue(
+    formData,
+    'productInfoNoticeRequest',
+    data.productInfoNotice,
+  )
+
+  data.options.forEach((option, index) => {
+    const productId = productIdsByOptionIndex[index]
+    appendFormValue(
+      formData,
+      `products[${index}]`,
+      mapOptionToRequest(
+        option,
+        productId === undefined ? null : productId,
+      ),
+    )
+  })
+
+  if (data.mainImage) {
+    formData.append('thumbnailImgFile', data.mainImage, data.mainImage.name)
+  } else if (existingThumbnailUrl) {
+    formData.append('existingThumbnailUrl', existingThumbnailUrl)
+  }
+
+  existingSubImageUrls.forEach((url) => {
+    formData.append('existingSubImageUrls', url)
+  })
+
+  const subImages =
+    newSubImageFiles.length > 0
+      ? newSubImageFiles
+      : (data.extraImages?.map((item) => item.file) ?? [])
+
+  subImages.forEach((file) => {
+    formData.append('newSubImages', file, file.name)
   })
 
   boardDetailImages.forEach((file) => {

--- a/apps/seller/src/features/products/create/create-form/index.ts
+++ b/apps/seller/src/features/products/create/create-form/index.ts
@@ -13,7 +13,7 @@ export {
 export { initCreateFunnelRouterSubscription } from './init-create-funnel-router-subscription'
 export { hasCreateFormInput } from './has-create-form-input.utils'
 export { mapToBackendCategory } from './map-to-backend-category.utils'
-export { buildProductBoardFormData } from './build-product-board-form-data.utils'
+export { buildProductBoardFormData, buildUpdateProductBoardFormData } from './build-product-board-form-data.utils'
 export { InfoTooltip } from './info-tooltip.ui'
 export {
   CREATE_PRODUCT_DEFAULT_VALUES,
@@ -24,6 +24,7 @@ export { useCreateFormPersistence } from './use-create-form-persistence.hook'
 export { useCreateFunnelEntry } from './use-create-funnel-entry.hook'
 export { useCreateProductForm } from './use-create-product-form.hook'
 export { useCreateProductBoardMutation } from './use-create-product-board.mutation'
+export { useUpdateProductBoardMutation } from './use-update-product-board.mutation'
 export { useSubmitCreateForm } from './use-submit-create-form.hook'
 export { useProductCreationStore } from './product-creation.store'
 export * from './product-create.types'

--- a/apps/seller/src/features/products/create/create-form/use-create-form-persistence.hook.ts
+++ b/apps/seller/src/features/products/create/create-form/use-create-form-persistence.hook.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react'
 import { useFormContext } from 'react-hook-form'
 
 import { debounce } from '@/shared/utils/debounce'
+import { toProductionStartTimeFormValue } from '@/entity/products/create/create-info/production-time.constants'
 
 import {
   CreateFormEntryMode,
@@ -34,6 +35,7 @@ export function useCreateFormPersistence(entryMode: CreateFormEntryMode) {
 
     form.reset({
       ...formValues,
+      productionTime: toProductionStartTimeFormValue(formValues.productionTime),
       mainImage: fileData?.mainImage ?? null,
       extraImages: fileData?.extraImages ?? [],
     } as CreateProductForm)

--- a/apps/seller/src/features/products/create/create-form/use-update-product-board.mutation.ts
+++ b/apps/seller/src/features/products/create/create-form/use-update-product-board.mutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { productQueries, updateProductBoard } from '@/entity/products'
+
+export const useUpdateProductBoardMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      boardId,
+      formData,
+    }: {
+      boardId: number
+      formData: FormData
+    }) => updateProductBoard(boardId, formData),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: productQueries.all(),
+      })
+    },
+  })
+}

--- a/apps/seller/src/features/products/product/filter/filter-category.tsx
+++ b/apps/seller/src/features/products/product/filter/filter-category.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
+import { useMemo } from 'react'
 
 import { Button, Dropdown, Input } from '@dessert/ui'
 
+import type { ProductBoardFilters } from '@/entity/products/product/product-board.type'
 import {
   BreadOptions,
   ProductFilterMainOption,
@@ -9,47 +10,98 @@ import {
   SnackOptions,
 } from '@/entity/products/product/product-filter-options.mock'
 
-export const FilterCategory = () => {
-  const [main, setMain] = useState<string>('')
-  const [sub, setSub] = useState<string>('')
-  const [searchOpt, setSearchOpt] = useState<string>('all')
-  const [keyword, setKeyword] = useState<string>('')
-  const subOptions =
-    main === 'bread' ? BreadOptions : main === 'snack' ? SnackOptions : []
+type FilterCategoryProps = {
+  filters: ProductBoardFilters
+  mainCategoryValue: string
+  subCategoryValue: string
+  searchOpt: string
+  onMainCategoryChange: (value: string) => void
+  onSubCategoryChange: (value: string) => void
+  onSearchOptChange: (value: string) => void
+  onFiltersChange: (next: ProductBoardFilters) => void
+  onSearch: () => void
+}
+
+export const FilterCategory = ({
+  filters,
+  mainCategoryValue,
+  subCategoryValue,
+  searchOpt,
+  onMainCategoryChange,
+  onSubCategoryChange,
+  onSearchOptChange,
+  onFiltersChange,
+  onSearch,
+}: FilterCategoryProps) => {
+  const subOptions = useMemo(
+    () =>
+      mainCategoryValue === 'bread'
+        ? BreadOptions
+        : mainCategoryValue === 'snack'
+          ? SnackOptions
+          : [],
+    [mainCategoryValue],
+  )
+
+  const handleKeywordChange = (keyword: string) => {
+    onFiltersChange({
+      ...filters,
+      keyword: keyword || undefined,
+    })
+  }
 
   return (
     <>
       <Dropdown
         options={ProductFilterMainOption}
-        value={main}
+        value={mainCategoryValue}
         placeholder="대분류"
         onSelect={(value) => {
-          setMain(value)
-          setSub('')
-          setKeyword('')
+          onMainCategoryChange(value)
+          onSubCategoryChange('')
+          const mainLabel = ProductFilterMainOption.find(
+            (option) => option.value === value,
+          )?.label
+
+          onFiltersChange({
+            ...filters,
+            mainCategory: mainLabel,
+            category: undefined,
+            keyword: undefined,
+          })
         }}
         className="w-0 min-w-[150px] shrink-0"
       />
       <Dropdown
         options={subOptions}
-        value={sub}
+        value={subCategoryValue}
         placeholder="중분류"
-        disabled={!main}
-        onSelect={setSub}
+        disabled={!mainCategoryValue}
+        onSelect={(value) => {
+          onSubCategoryChange(value)
+          const subLabel = subOptions.find(
+            (option) => option.value === value,
+          )?.label
+
+          onFiltersChange({
+            ...filters,
+            category: subLabel,
+          })
+        }}
         className="w-0 min-w-[150px] shrink-0"
       />
       <Dropdown
         options={SearchOptions}
         value={searchOpt}
         className="w-0 min-w-[150px] shrink-0"
-        onSelect={setSearchOpt}
+        onSelect={onSearchOptChange}
         placeholder="전체"
       />
       <Input
         placeholder="1~50자로 검색해 주세요"
-        value={keyword}
-        onChange={(e) => setKeyword(e.target.value)}
-        disabled={!main || !sub}
+        value={filters.keyword ?? ''}
+        onChange={(e) => handleKeywordChange(e.target.value)}
+        disabled={!mainCategoryValue || !subCategoryValue}
         className="flex-1"
         maxLength={50}
       />
@@ -57,7 +109,7 @@ export const FilterCategory = () => {
         title="조회"
         size="md"
         className="min-w-[72px]"
-        onClick={() => {}}
+        onClick={onSearch}
       />
     </>
   )

--- a/apps/seller/src/features/products/product/filter/filter-tabs.tsx
+++ b/apps/seller/src/features/products/product/filter/filter-tabs.tsx
@@ -1,27 +1,66 @@
 import { Tab, TabList, TabTrigger } from '@dessert/ui'
 
-export const FilterTabs = () => {
+import type {
+  ProductBoardStatus,
+  TabCounts,
+} from '@/entity/products/product/product-board.type'
+import { EMPTY_TAB_COUNTS } from '@/entity/products/product/product-board.type'
+
+const STATUS_TABS: Array<{
+  value: ProductBoardStatus
+  label: string
+  countKey: keyof TabCounts | 'ALL'
+}> = [
+  { value: '전체', label: '전체', countKey: 'ALL' },
+  { value: '판매중', label: '판매중', countKey: 'ON_SALE' },
+  { value: '품절', label: '품절', countKey: 'OUT_OF_STOCK' },
+  { value: '판매중지', label: '판매중지', countKey: 'STOPPED' },
+  { value: '판매대기', label: '판매대기', countKey: 'PENDING' },
+  { value: '판매금지', label: '판매금지', countKey: 'BANNED' },
+]
+
+function getTabCount(tabCounts: TabCounts, countKey: keyof TabCounts | 'ALL') {
+  if (countKey === 'ALL') {
+    return (
+      tabCounts.ON_SALE +
+      tabCounts.OUT_OF_STOCK +
+      tabCounts.STOPPED +
+      tabCounts.PENDING +
+      tabCounts.BANNED
+    )
+  }
+
+  return tabCounts[countKey]
+}
+
+type FilterTabsProps = {
+  saleStatus: ProductBoardStatus
+  tabCounts?: TabCounts
+  onStatusChange: (status: ProductBoardStatus) => void
+}
+
+export const FilterTabs = ({
+  saleStatus,
+  tabCounts = EMPTY_TAB_COUNTS,
+  onStatusChange,
+}: FilterTabsProps) => {
   return (
-    <Tab variant={'btn'} className="mb-5" defaultValue="all">
+    <Tab
+      variant="btn"
+      className="mb-5"
+      value={saleStatus}
+      onValueChange={(value) => onStatusChange(value as ProductBoardStatus)}
+    >
       <TabList>
-        <TabTrigger value="all" number={99}>
-          전체
-        </TabTrigger>
-        <TabTrigger value="active" number={50}>
-          판매중
-        </TabTrigger>
-        <TabTrigger value="inactive" number={55}>
-          품절
-        </TabTrigger>
-        <TabTrigger value="inactive2" number={55}>
-          판매중지
-        </TabTrigger>
-        <TabTrigger value="inactive3" number={55}>
-          판매대기
-        </TabTrigger>
-        <TabTrigger value="inactive4" number={55}>
-          판매금지
-        </TabTrigger>
+        {STATUS_TABS.map((tab) => (
+          <TabTrigger
+            key={tab.value}
+            value={tab.value}
+            number={getTabCount(tabCounts, tab.countKey)}
+          >
+            {tab.label}
+          </TabTrigger>
+        ))}
       </TabList>
     </Tab>
   )

--- a/apps/seller/src/features/products/product/filter/product-filter.hook.ts
+++ b/apps/seller/src/features/products/product/filter/product-filter.hook.ts
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+
+import { DEFAULT_PRODUCT_BOARD_SORT } from '@/entity/products/product/product-board-sort.constants'
+import type {
+  ProductBoardFilters,
+  ProductBoardStatus,
+} from '@/entity/products/product/product-board.type'
+
+const DEFAULT_SIZE = 20
+
+export const createInitialProductBoardFilters = (
+  saleStatus: ProductBoardStatus = '전체',
+): ProductBoardFilters => ({
+  saleStatus,
+  page: 0,
+  size: DEFAULT_SIZE,
+  sortBy: DEFAULT_PRODUCT_BOARD_SORT,
+})
+
+export function useProductBoardFilter(
+  initialStatus: ProductBoardStatus = '전체',
+) {
+  const initialState = createInitialProductBoardFilters(initialStatus)
+
+  const [draftFilters, setDraftFilters] =
+    useState<ProductBoardFilters>(initialState)
+  const [appliedFilters, setAppliedFilters] =
+    useState<ProductBoardFilters>(initialState)
+
+  const apply = () => {
+    const trimmedKeyword = draftFilters.keyword?.trim()
+
+    setAppliedFilters({
+      ...draftFilters,
+      page: 0,
+      keyword: trimmedKeyword || undefined,
+    })
+  }
+
+  const reset = (saleStatus?: ProductBoardStatus) => {
+    const next = createInitialProductBoardFilters(
+      saleStatus ?? initialStatus,
+    )
+    setDraftFilters(next)
+    setAppliedFilters(next)
+  }
+
+  return {
+    draftFilters,
+    setDraftFilters,
+    appliedFilters,
+    setAppliedFilters,
+    apply,
+    reset,
+  }
+}

--- a/apps/seller/src/features/products/product/product-list/product-list-columns.tsx
+++ b/apps/seller/src/features/products/product/product-list/product-list-columns.tsx
@@ -14,6 +14,13 @@ type Args = {
   onCopyRow: (row: ProductType) => void
 }
 
+const widthMeta = (widthClass: string) =>
+  ({
+    flexible: true,
+    headerClassName: widthClass,
+    className: widthClass,
+  }) as const
+
 export const getResultColumns = ({
   allSelected,
   selectedIdSet,
@@ -34,24 +41,24 @@ export const getResultColumns = ({
         />
       )
     },
-    size: 40,
+    meta: widthMeta('w-[5%]'),
   },
   {
     header: '등록상품',
     accessorKey: 'productName',
     cell: ({ row }) => (
-      <div className="flex items-center gap-16">
+      <div className="flex min-w-0 items-center gap-16">
         <img
           src={row.original.thumbnailUrl}
           alt={row.original.productName}
           className="h-header w-[80px] shrink-0 rounded-8 bg-gray-100 object-cover"
         />
-        <div className="line-clamp-2 text-left typo-title-14-r text-gray-900">
+        <div className="line-clamp-2 min-w-0 flex-1 text-left typo-title-14-r text-gray-900">
           {row.original.productName}
         </div>
       </div>
     ),
-    size: 440,
+    meta: widthMeta('w-[32%]'),
   },
   {
     header: '재고상태',
@@ -61,53 +68,51 @@ export const getResultColumns = ({
         {row.original.stockStatus}
       </div>
     ),
-    size: 100,
+    meta: widthMeta('w-[11%]'),
   },
   {
     header: '판매가',
     accessorKey: 'salePrice',
     cell: ({ row }) => (
-      <div className="flex flex-col items-end">
-        <div className="text-center typo-body-12-r text-gray-500 line-through">
+      <div className="flex flex-col items-center">
+        <div className="typo-body-12-r text-gray-500 line-through">
           {`${row.original.originPrice.toLocaleString()}원`}
         </div>
-        <div className="text-center typo-title-14-sb text-gray-900">
+        <div className="typo-title-14-sb text-gray-900">
           {`${row.original.salePrice.toLocaleString()}원`}
         </div>
       </div>
     ),
-    size: 120,
+    meta: widthMeta('w-[14%]'),
   },
   {
     header: '배송비',
     accessorKey: 'shipping',
     cell: ({ row }) => (
-      <div className="flex flex-col items-end">
-        <div className="flex flex-col items-end">
-          <div className="text-center typo-title-14-sb text-gray-900">
-            {`${row.original.shipping.price.toLocaleString()}원`}
-          </div>
-          <div className="text-center typo-body-12-r text-primary-500">
-            {row.original.shipping.type}
-          </div>
+      <div className="flex flex-col items-center">
+        <div className="typo-title-14-sb text-gray-900">
+          {`${row.original.shipping.price.toLocaleString()}원`}
+        </div>
+        <div className="typo-body-12-r text-primary-500">
+          {row.original.shipping.type}
         </div>
         {row.original.shipping.minimumPrice != null && (
-          <div className="text-center typo-body-12-r text-gray-500">
+          <div className="typo-body-12-r text-gray-500">
             {`${row.original.shipping.minimumPrice.toLocaleString()}원`}
           </div>
         )}
       </div>
     ),
-    size: 160,
+    meta: widthMeta('w-[12%]'),
   },
   {
     header: '판매상태',
     accessorKey: 'status',
     cell: ({ row }) => <ProductListCellStatus status={row.original.status} />,
-    size: 100,
+    meta: widthMeta('w-[12%]'),
   },
   {
-    header: '',
+    header: '관리',
     id: 'actions',
     cell: ({ row }) => {
       const onEdit = () => {}
@@ -129,6 +134,6 @@ export const getResultColumns = ({
         </div>
       )
     },
-    size: 100,
+    meta: widthMeta('w-[14%]'),
   },
 ]

--- a/apps/seller/src/features/products/product/product-list/product-list-columns.tsx
+++ b/apps/seller/src/features/products/product/product-list/product-list-columns.tsx
@@ -42,9 +42,9 @@ export const getResultColumns = ({
     cell: ({ row }) => (
       <div className="flex items-center gap-16">
         <img
-          src="https://picsum.photos/200/300"
+          src={row.original.thumbnailUrl}
           alt={row.original.productName}
-          className="h-header w-[80px] shrink-0 rounded-8"
+          className="h-header w-[80px] shrink-0 rounded-8 bg-gray-100 object-cover"
         />
         <div className="line-clamp-2 text-left typo-title-14-r text-gray-900">
           {row.original.productName}

--- a/apps/seller/src/features/products/product/product-list/product-list-table.tsx
+++ b/apps/seller/src/features/products/product/product-list/product-list-table.tsx
@@ -62,8 +62,9 @@ export const ResultTable = ({
       <Table
         data={tableData}
         columns={columns}
+        tableClassName="w-full table-fixed"
         topArea={
-          <div className="flex w-full justify-between px-[19px] py-16 pb-12">
+          <div className="flex w-full items-center justify-between gap-16">
             <div className="flex items-center gap-10">
               <ProductTopAreaSort sortBy={sortBy} onSortChange={onSortChange} />
               <ProductTopAreaCounter

--- a/apps/seller/src/features/products/product/product-list/product-list-table.tsx
+++ b/apps/seller/src/features/products/product/product-list/product-list-table.tsx
@@ -1,6 +1,7 @@
 import { Pagination, Table } from '@dessert/ui'
 
-import { ProductResultData } from '@/entity/products/product/product-data.mock'
+import type { ProductType } from '@/entity/products/product/product.type'
+import type { ProductBoardSortType } from '@/entity/products/product/product-board-sort.constants'
 
 import { getResultColumns } from './product-list-columns'
 import { useProductList } from './product-list.hook'
@@ -8,7 +9,31 @@ import ProductTopAreaBulkDelete from './product-top-area/product-top-area-bulk-d
 import ProductTopAreaCounter from './product-top-area/product-top-area-counter'
 import ProductTopAreaSort from './product-top-area/product-top-area-sort'
 
-export const ResultTable = () => {
+type ResultTableProps = {
+  data: ProductType[]
+  totalElements: number
+  currentPage: number
+  totalPages: number
+  sortBy: ProductBoardSortType
+  isLoading?: boolean
+  isError?: boolean
+  onSortChange: (sortBy: ProductBoardSortType) => void
+  onPageChange: (page: number) => void
+  onRetry?: () => void
+}
+
+export const ResultTable = ({
+  data,
+  totalElements,
+  currentPage,
+  totalPages,
+  sortBy,
+  isLoading = false,
+  isError = false,
+  onSortChange,
+  onPageChange,
+  onRetry,
+}: ResultTableProps) => {
   const {
     tableData,
     selectedIds,
@@ -18,7 +43,8 @@ export const ResultTable = () => {
     selectedIdSet,
     handleCopyRow,
     handleDelete,
-  } = useProductList({ data: ProductResultData })
+    isDeleting,
+  } = useProductList({ data })
 
   const columns = getResultColumns({
     selectedIds,
@@ -29,26 +55,65 @@ export const ResultTable = () => {
     onCopyRow: handleCopyRow,
   })
 
+  const isEmpty = !isLoading && !isError && tableData.length === 0
+
   return (
-    <Table
-      data={tableData}
-      columns={columns}
-      topArea={
-        <div className="flex w-full justify-between px-[19px] py-16 pb-12">
-          <div className="flex items-center gap-10">
-            <ProductTopAreaSort />
-            <ProductTopAreaCounter
-              selectedIds={selectedIds}
-              tableData={tableData.length}
-            />
-            <ProductTopAreaBulkDelete
-              onDelete={handleDelete}
-              disabled={selectedIds.length === 0}
+    <div>
+      <Table
+        data={tableData}
+        columns={columns}
+        topArea={
+          <div className="flex w-full justify-between px-[19px] py-16 pb-12">
+            <div className="flex items-center gap-10">
+              <ProductTopAreaSort sortBy={sortBy} onSortChange={onSortChange} />
+              <ProductTopAreaCounter
+                selectedIds={selectedIds}
+                tableData={totalElements}
+              />
+              <ProductTopAreaBulkDelete
+                onDelete={() => {
+                  void handleDelete()
+                }}
+                disabled={selectedIds.length === 0 || isDeleting}
+              />
+            </div>
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={onPageChange}
             />
           </div>
-          <Pagination currentPage={1} totalPages={2} />
+        }
+      />
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-40 typo-title-14-r text-gray-500">
+          상품 목록을 불러오는 중입니다.
         </div>
-      }
-    />
+      )}
+
+      {isError && (
+        <div className="flex flex-col items-center justify-center gap-12 py-40">
+          <p className="typo-title-14-r text-gray-500">
+            상품 목록을 불러오지 못했습니다.
+          </p>
+          {onRetry && (
+            <button
+              type="button"
+              className="typo-title-14-m text-primary-500 underline"
+              onClick={onRetry}
+            >
+              다시 시도
+            </button>
+          )}
+        </div>
+      )}
+
+      {isEmpty && (
+        <div className="flex items-center justify-center py-40 typo-title-14-r text-gray-500">
+          등록된 상품이 없습니다.
+        </div>
+      )}
+    </div>
   )
 }

--- a/apps/seller/src/features/products/product/product-list/product-list.hook.ts
+++ b/apps/seller/src/features/products/product/product-list/product-list.hook.ts
@@ -2,9 +2,13 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { ProductType } from '@/entity/products/product/product.type'
 
+import { useDeleteProductBoardsMutation } from './use-delete-product-boards.mutation'
+
 export const useProductList = ({ data }: { data: ProductType[] }) => {
   const [tableData, setTableData] = useState<ProductType[]>([])
   const [selectedIds, setSelectedIds] = useState<string[]>([])
+  const { mutateAsync: deleteBoards, isPending: isDeleting } =
+    useDeleteProductBoardsMutation()
 
   useEffect(() => {
     setTableData(data)
@@ -47,9 +51,16 @@ export const useProductList = ({ data }: { data: ProductType[] }) => {
     ])
   }
 
-  const handleDelete = () => {
-    const selectedSet = new Set(selectedIds)
-    setTableData((prev) => prev.filter((row) => !selectedSet.has(row.id)))
+  const handleDelete = async () => {
+    if (selectedIds.length === 0 || isDeleting) return
+
+    const boardIds = selectedIds
+      .map((id) => Number(id))
+      .filter((id) => Number.isFinite(id))
+
+    if (boardIds.length === 0) return
+
+    await deleteBoards(boardIds)
     setSelectedIds([])
   }
 
@@ -64,5 +75,6 @@ export const useProductList = ({ data }: { data: ProductType[] }) => {
     toggleRow,
     handleCopyRow,
     handleDelete,
+    isDeleting,
   }
 }

--- a/apps/seller/src/features/products/product/product-list/product-top-area/product-top-area-sort.tsx
+++ b/apps/seller/src/features/products/product/product-list/product-top-area/product-top-area-sort.tsx
@@ -1,21 +1,25 @@
-import { useState } from 'react'
-
 import { Dropdown } from '@dessert/ui'
 
-const sortOptions = [
-  { label: '최신순', value: 'created_desc' },
-  { label: '오래된순', value: 'created_asc' },
-  { label: '상품명순', value: 'name_asc' },
-]
+import {
+  PRODUCT_BOARD_SORT_OPTIONS,
+  type ProductBoardSortType,
+} from '@/entity/products/product/product-board-sort.constants'
 
-const ProductTopAreaSort = () => {
-  const [sort, setSort] = useState('created_desc')
+type ProductTopAreaSortProps = {
+  sortBy: ProductBoardSortType
+  onSortChange: (sortBy: ProductBoardSortType) => void
+}
+
+const ProductTopAreaSort = ({
+  sortBy,
+  onSortChange,
+}: ProductTopAreaSortProps) => {
   return (
     <Dropdown
-      options={sortOptions}
-      value={sort}
+      options={[...PRODUCT_BOARD_SORT_OPTIONS]}
+      value={sortBy}
       placeholder="최신순"
-      onSelect={setSort}
+      onSelect={(value) => onSortChange(value as ProductBoardSortType)}
       className="w-0 min-w-[150px] shrink-0"
     />
   )

--- a/apps/seller/src/features/products/product/product-list/use-delete-product-boards.mutation.ts
+++ b/apps/seller/src/features/products/product/product-list/use-delete-product-boards.mutation.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from '@dessert/ui'
+
+import {
+  deleteProductBoards,
+  getMyStore,
+  productQueries,
+} from '@/entity/products'
+
+export const useDeleteProductBoardsMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (boardIds: number[]) => {
+      const store = await getMyStore()
+      return deleteProductBoards(store.storeId, boardIds)
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: productQueries.all(),
+      })
+      toast.success('선택한 상품을 삭제했습니다.')
+    },
+    onError: (error: Error) => {
+      toast.error(
+        '상품 삭제에 실패했습니다.',
+        error.message || '다시 시도해주세요.',
+      )
+    },
+  })
+}

--- a/apps/seller/src/pages/products/product/product-page.tsx
+++ b/apps/seller/src/pages/products/product/product-page.tsx
@@ -1,18 +1,107 @@
+import { useMemo, useState } from 'react'
+
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+
+import { productQueries } from '@/entity/products'
+import { mapProductBoardItemToProductType } from '@/entity/products/product/product-board.mapper'
+import { DEFAULT_PRODUCT_BOARD_SORT } from '@/entity/products/product/product-board-sort.constants'
+import type { ProductBoardSortType } from '@/entity/products/product/product-board-sort.constants'
+import type { ProductBoardStatus } from '@/entity/products/product/product-board.type'
+import { EMPTY_TAB_COUNTS } from '@/entity/products/product/product-board.type'
 import { FilterCategory } from '@/features/products/product/filter/filter-category'
 import { FilterTabs } from '@/features/products/product/filter/filter-tabs'
+import { useProductBoardFilter } from '@/features/products/product/filter/product-filter.hook'
 import { ResultTable } from '@/features/products/product/product-list/product-list-table'
 import { cn } from '@/shared/libs/utils'
 
 const ContainerStyle = 'rounded-10 border border-gray-300 bg-white'
+
 function ProductsPage() {
+  const {
+    draftFilters,
+    setDraftFilters,
+    appliedFilters,
+    setAppliedFilters,
+    apply,
+    reset,
+  } = useProductBoardFilter('전체')
+
+  const [mainCategoryValue, setMainCategoryValue] = useState('')
+  const [subCategoryValue, setSubCategoryValue] = useState('')
+  const [searchOpt, setSearchOpt] = useState('all')
+
+  const { data, isLoading, isFetching, isError, refetch } = useQuery({
+    ...productQueries.list(appliedFilters),
+    placeholderData: keepPreviousData,
+  })
+
+  const tableData = useMemo(
+    () => (data?.boards ?? []).map(mapProductBoardItemToProductType),
+    [data?.boards],
+  )
+
+  const totalElements = data?.totalElements ?? 0
+  const totalPages = data?.totalPages ?? 1
+  const currentPage = (data?.page ?? appliedFilters.page ?? 0) + 1
+  const sortBy = appliedFilters.sortBy ?? DEFAULT_PRODUCT_BOARD_SORT
+  const tabCounts = data?.tabCounts ?? EMPTY_TAB_COUNTS
+  const showInitialLoading = isLoading && !data
+
+  const handleStatusChange = (saleStatus: ProductBoardStatus) => {
+    setMainCategoryValue('')
+    setSubCategoryValue('')
+    setSearchOpt('all')
+    reset(saleStatus)
+  }
+
+  const handleSearch = () => {
+    apply()
+  }
+
+  const handleSortChange = (nextSortBy: ProductBoardSortType) => {
+    setDraftFilters((prev) => ({ ...prev, sortBy: nextSortBy }))
+    setAppliedFilters((prev) => ({ ...prev, sortBy: nextSortBy, page: 0 }))
+  }
+
+  const handlePageChange = (page: number) => {
+    setAppliedFilters((prev) => ({ ...prev, page: page - 1 }))
+  }
+
   return (
     <div>
-      <FilterTabs />
+      <FilterTabs
+        saleStatus={appliedFilters.saleStatus}
+        tabCounts={tabCounts}
+        onStatusChange={handleStatusChange}
+      />
       <div className={cn('flex gap-10 px-24 py-16', ContainerStyle)}>
-        <FilterCategory />
+        <FilterCategory
+          filters={draftFilters}
+          mainCategoryValue={mainCategoryValue}
+          subCategoryValue={subCategoryValue}
+          searchOpt={searchOpt}
+          onMainCategoryChange={setMainCategoryValue}
+          onSubCategoryChange={setSubCategoryValue}
+          onSearchOptChange={setSearchOpt}
+          onFiltersChange={setDraftFilters}
+          onSearch={handleSearch}
+        />
       </div>
       <div className={cn('mt-10 overflow-hidden bg-white')}>
-        <ResultTable />
+        <ResultTable
+          data={tableData}
+          totalElements={totalElements}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          sortBy={sortBy}
+          isLoading={showInitialLoading || (isFetching && !data)}
+          isError={isError && !data}
+          onSortChange={handleSortChange}
+          onPageChange={handlePageChange}
+          onRetry={() => {
+            void refetch()
+          }}
+        />
       </div>
     </div>
   )

--- a/apps/seller/src/shared/utils/axios.ts
+++ b/apps/seller/src/shared/utils/axios.ts
@@ -26,9 +26,14 @@ const clearSessionAndRedirectToAuth = () => {
   }
 }
 
-// 모든 요청에 Bearer Token 추가
+// FormData는 Content-Type을 수동 지정하지 않음.
+// axios 기본 application/json을 제거해야 boundary 포함 multipart가 설정됩니다.
 client.interceptors.request.use(
   (config) => {
+    if (typeof FormData !== 'undefined' && config.data instanceof FormData) {
+      config.headers.delete('Content-Type')
+    }
+
     const token = getCookie('accessToken')
     if (token) {
       config.headers.Authorization = `Bearer ${token}`

--- a/apps/seller/vite.config.ts
+++ b/apps/seller/vite.config.ts
@@ -10,7 +10,7 @@ export default mergeConfig(baseViteConfig, {
 
   // 포트지정
   server: {
-    port: 6075,
+    port: 3000,
   },
 
   resolve: {

--- a/packages/ui/src/table/table.tsx
+++ b/packages/ui/src/table/table.tsx
@@ -47,12 +47,17 @@ function Table<T>({
   return (
     <div className="overflow-hidden rounded-md border border-gray-300 bg-white">
       {topArea && (
-        <div className="flex items-center justify-between border-b border-gray-200 px-24 py-16">
+        <div className="flex w-full items-center justify-between border-b border-gray-200 px-24 py-16">
           {topArea}
         </div>
       )}
-      <div className="overflow-auto" style={{ maxHeight: maxHeight }}>
-        <table className={cn('border-collapse', tableClassName ?? 'min-w-max')}>
+      <div className="w-full overflow-auto" style={{ maxHeight: maxHeight }}>
+        <table
+          className={cn(
+            'w-full border-collapse',
+            tableClassName ?? 'min-w-max',
+          )}
+        >
           <thead className="sticky top-0 z-10 bg-gray-200">
             {getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id} className="h-40">


### PR DESCRIPTION
## 작업 내용 및 테스트 방법

### 1. 주요 작업 내용

* **상품 목록 조회 API 연동 (GET /api/v1/seller/boards)**
* 백엔드 DTO 스펙에 맞춘 응답 데이터 매핑

* **UI / 레이아웃 개선**
* 상품 목록 테이블의 width: 100% 적용으로 우측 빈 공간 레이아웃 보정
* 컬럼별 너비 비율 배분 및 정렬 보정



---

### 2. 테스트 방법

1. **상품 목록 조회**
* 셀러 대시보드 내 상품 관리 페이지 접근 시 목록이 정상 노출되는지 확인



---

## To reviewers

* 테이블 우측이 비어 보이던 레이아웃 이슈를 해결하기 위해 컬럼 비율을 균등 배분했습니다. 혹시 해상도별로 어색한 부분이 있다면 피드백 부탁드립니다!