### PR TITLE
✨ Feat: [admin][A04] 공지사항 관리 화면 퍼블리싱

### DIFF
--- a/apps/admin/src/app/main.tsx
+++ b/apps/admin/src/app/main.tsx
@@ -4,6 +4,7 @@ import '@/styles/index.css'
 import ReactDOM from 'react-dom/client'
 import { Navigate, createBrowserRouter } from 'react-router-dom'
 
+import { GuestOnlyRoute, ProtectedRoute } from '@/features/auth'
 import AuthPage from '@/pages/auth/auth-page'
 import { NoticePage } from '@/pages/home-page/notice'
 import { AllProductPage } from '@/pages/product/all-product'
@@ -18,42 +19,52 @@ import FixedLayout from './fixed-layout'
 
 const router = createBrowserRouter([
   {
-    path: ROUTES.HOME,
-    element: <FixedLayout />,
+    element: <ProtectedRoute />,
     children: [
       {
-        index: true,
-        element: <Navigate to={ROUTES.STORE.MEMBER_APPROVAL} replace />,
-      },
-      {
-        path: ROUTES.STORE.MEMBER_APPROVAL,
-        element: <MemberApprovalPage />,
-      },
-      {
-        path: ROUTES.STORE.NAME_CHANGE_APPROVAL,
-        element: <NameChangeApprovalPage />,
-      },
-      {
-        path: ROUTES.STORE.REGISTRATION,
-        element: <StoreRegistrationPage />,
-      },
-      {
-        path: ROUTES.PRODUCTS.UPLOAD_APPROVAL,
-        element: <UploadApprovalPage />,
-      },
-      {
-        path: ROUTES.PRODUCTS.ALL,
-        element: <AllProductPage />,
-      },
-      {
-        path: ROUTES.HOMEPAGE.NOTICE,
-        element: <NoticePage />,
+        path: ROUTES.HOME,
+        element: <FixedLayout />,
+        children: [
+          {
+            index: true,
+            element: <Navigate to={ROUTES.STORE.MEMBER_APPROVAL} replace />,
+          },
+          {
+            path: ROUTES.STORE.MEMBER_APPROVAL,
+            element: <MemberApprovalPage />,
+          },
+          {
+            path: ROUTES.STORE.NAME_CHANGE_APPROVAL,
+            element: <NameChangeApprovalPage />,
+          },
+          {
+            path: ROUTES.STORE.REGISTRATION,
+            element: <StoreRegistrationPage />,
+          },
+          {
+            path: ROUTES.PRODUCTS.UPLOAD_APPROVAL,
+            element: <UploadApprovalPage />,
+          },
+          {
+            path: ROUTES.PRODUCTS.ALL,
+            element: <AllProductPage />,
+          },
+          {
+            path: ROUTES.HOMEPAGE.NOTICE,
+            element: <NoticePage />,
+          },
+        ],
       },
     ],
   },
   {
-    path: ROUTES.LOGIN,
-    element: <AuthPage />,
+    element: <GuestOnlyRoute />,
+    children: [
+      {
+        path: ROUTES.LOGIN,
+        element: <AuthPage />,
+      },
+    ],
   },
 ])
 

--- a/apps/admin/src/app/main.tsx
+++ b/apps/admin/src/app/main.tsx
@@ -6,7 +6,11 @@ import { Navigate, createBrowserRouter } from 'react-router-dom'
 
 import { GuestOnlyRoute, ProtectedRoute } from '@/features/auth'
 import AuthPage from '@/pages/auth/auth-page'
-import { NoticePage } from '@/pages/home-page/notice'
+import {
+  NoticeCreatePage,
+  NoticeEditPage,
+  NoticePage,
+} from '@/pages/home-page/notice'
 import { AllProductPage } from '@/pages/product/all-product'
 import { UploadApprovalPage } from '@/pages/product/upload-approval'
 import { MemberApprovalPage } from '@/pages/store/member-approval'
@@ -52,6 +56,14 @@ const router = createBrowserRouter([
           {
             path: ROUTES.HOMEPAGE.NOTICE,
             element: <NoticePage />,
+          },
+          {
+            path: ROUTES.HOMEPAGE.NOTICE_CREATE,
+            element: <NoticeCreatePage />,
+          },
+          {
+            path: ROUTES.HOMEPAGE.NOTICE_EDIT,
+            element: <NoticeEditPage />,
           },
         ],
       },

--- a/apps/admin/src/entity/home-page/notice/index.ts
+++ b/apps/admin/src/entity/home-page/notice/index.ts
@@ -1,0 +1,2 @@
+export type { Notice, NoticeFormValues } from './notice.type'
+export { noticeMockData } from './notice.mock'

--- a/apps/admin/src/entity/home-page/notice/notice.mock.ts
+++ b/apps/admin/src/entity/home-page/notice/notice.mock.ts
@@ -1,0 +1,26 @@
+import type { Notice } from './notice.type'
+
+/**
+ * 목록 조회 API 연동 전까지 사용하는 임시 데이터.
+ * 백엔드 응답에 공지사항 ID가 포함되면 제거한다.
+ */
+export const noticeMockData: Notice[] = [
+  {
+    id: 1,
+    title: '비건빵 주문 시 주의사항',
+    createdAt: '2025-10-31 00:00:00',
+    modifiedAt: '2025-10-31 00:00:00',
+  },
+  {
+    id: 2,
+    title: '개인정보 보호 시 주의사항',
+    createdAt: '2025-10-31 00:00:00',
+    modifiedAt: '2025-10-31 00:00:00',
+  },
+  {
+    id: 3,
+    title: '서버 점검 일정 안내',
+    createdAt: '2025-10-31 00:00:00',
+    modifiedAt: '2025-10-31 00:00:00',
+  },
+]

--- a/apps/admin/src/entity/home-page/notice/notice.type.ts
+++ b/apps/admin/src/entity/home-page/notice/notice.type.ts
@@ -1,0 +1,11 @@
+export interface Notice {
+  id: number
+  title: string
+  createdAt: string
+  modifiedAt: string
+}
+
+export interface NoticeFormValues {
+  title: string
+  content: string
+}

--- a/apps/admin/src/features/auth/auth-guard.ui.tsx
+++ b/apps/admin/src/features/auth/auth-guard.ui.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react'
+
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
+
+import { useAuthStore } from '@/entity/auth'
+import { ROUTES, TOKEN_COOKIE_KEYS } from '@/shared/constant'
+import { getCookie } from '@/shared/utils'
+
+export interface RedirectState {
+  from?: string
+}
+
+const hasValidSession = (isLoggedIn: boolean) =>
+  isLoggedIn && Boolean(getCookie(TOKEN_COOKIE_KEYS.ACCESS))
+
+/** 스토어에는 로그인 상태로 남아 있지만 토큰이 사라진 경우 정리 */
+const useClearStaleSession = (isLoggedIn: boolean) => {
+  const logout = useAuthStore((state) => state.logout)
+
+  useEffect(() => {
+    if (isLoggedIn && !getCookie(TOKEN_COOKIE_KEYS.ACCESS)) {
+      logout()
+    }
+  }, [isLoggedIn, logout])
+}
+
+/** 관리자 화면 - 로그인하지 않았다면 로그인 화면으로 이동 */
+export const ProtectedRoute = () => {
+  const location = useLocation()
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
+
+  useClearStaleSession(isLoggedIn)
+
+  if (!hasValidSession(isLoggedIn)) {
+    const state: RedirectState = {
+      from: `${location.pathname}${location.search}`,
+    }
+    return <Navigate to={ROUTES.LOGIN} replace state={state} />
+  }
+
+  return <Outlet />
+}
+
+/** 로그인 화면 - 이미 로그인했다면 관리자 화면으로 이동 */
+export const GuestOnlyRoute = () => {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
+
+  useClearStaleSession(isLoggedIn)
+
+  if (hasValidSession(isLoggedIn)) {
+    return <Navigate to={ROUTES.HOME} replace />
+  }
+
+  return <Outlet />
+}

--- a/apps/admin/src/features/auth/index.ts
+++ b/apps/admin/src/features/auth/index.ts
@@ -1,3 +1,5 @@
+export { GuestOnlyRoute, ProtectedRoute } from './auth-guard.ui'
+export type { RedirectState } from './auth-guard.ui'
 export { LoginFooter } from './login-footer.ui'
 export { AuthLoginImage } from './login-image.ui'
 export { useAdminLoginMutation } from './login.mutation'

--- a/apps/admin/src/features/auth/login-form.hook.ts
+++ b/apps/admin/src/features/auth/login-form.hook.ts
@@ -1,13 +1,18 @@
 import { toast } from '@dessert/ui'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import { ROUTES } from '@/shared/constant'
 
 import { useAdminLoginMutation } from './login.mutation'
 import { LoginFormValues, loginSchema } from './login.schema'
 
+import type { RedirectState } from './auth-guard.ui'
+
 export const useLoginForm = () => {
   const navigate = useNavigate()
+  const location = useLocation()
   const {
     register,
     handleSubmit,
@@ -23,7 +28,8 @@ export const useLoginForm = () => {
     mutate(data, {
       onSuccess: () => {
         toast.success('로그인 성공했어요')
-        navigate('/', { replace: true })
+        const { from } = (location.state ?? {}) as RedirectState
+        navigate(from ?? ROUTES.HOME, { replace: true })
       },
       onError: () => {
         toast.error('로그인 정보를 확인하세요', '아이디/비밀번호를 확인하세요')

--- a/apps/admin/src/features/auth/logout.hook.ts
+++ b/apps/admin/src/features/auth/logout.hook.ts
@@ -1,6 +1,8 @@
 import { toast } from '@dessert/ui'
 import { useNavigate } from 'react-router-dom'
 
+import { ROUTES } from '@/shared/constant'
+
 import { useAdminLogoutMutation } from './logout.mutation'
 
 export const useLogout = () => {
@@ -11,10 +13,12 @@ export const useLogout = () => {
     mutate(undefined, {
       onSuccess: () => {
         toast.success('로그아웃 되었어요')
-        navigate('/login', { replace: true })
       },
       onError: () => {
-        toast.error('로그아웃 실패', '다시 시도해주세요')
+        toast.error('로그아웃 처리 중 문제가 생겼어요', '다시 로그인해 주세요')
+      },
+      onSettled: () => {
+        navigate(ROUTES.LOGIN, { replace: true })
       },
     })
   }

--- a/apps/admin/src/features/auth/logout.mutation.ts
+++ b/apps/admin/src/features/auth/logout.mutation.ts
@@ -8,6 +8,6 @@ export const useAdminLogoutMutation = () => {
   return useMutation({
     mutationKey: authKeys.all,
     mutationFn: adminLogout,
-    onSuccess: logout,
+    onSettled: logout,
   })
 }

--- a/apps/admin/src/features/home-page/notice/index.ts
+++ b/apps/admin/src/features/home-page/notice/index.ts
@@ -1,0 +1,5 @@
+export { NoticeActionGroup } from './notice-action-group.ui'
+export { NoticeDeleteConfirmDialog } from './notice-delete-confirm-dialog.ui'
+export { NoticeForm } from './notice-form.ui'
+export { NoticeTable } from './notice-table.ui'
+export { getNoticeColumns } from './notice-columns.util'

--- a/apps/admin/src/features/home-page/notice/notice-action-group.ui.tsx
+++ b/apps/admin/src/features/home-page/notice/notice-action-group.ui.tsx
@@ -1,0 +1,44 @@
+import { Button, Pagination } from '@dessert/ui'
+
+interface NoticeActionGroupProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+  onCreate: () => void
+  onDelete: () => void
+  isDeleteDisabled?: boolean
+}
+
+export const NoticeActionGroup = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+  onCreate,
+  onDelete,
+  isDeleteDisabled = false,
+}: NoticeActionGroupProps) => {
+  return (
+    <div className="flex w-full items-center justify-between">
+      <div className="flex items-center gap-12">
+        <Button
+          title="등록"
+          size="sm"
+          variant="primary-outlined"
+          onClick={onCreate}
+        />
+        <Button
+          title="삭제"
+          size="sm"
+          variant="secondary-outlined"
+          disabled={isDeleteDisabled}
+          onClick={onDelete}
+        />
+      </div>
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={onPageChange}
+      />
+    </div>
+  )
+}

--- a/apps/admin/src/features/home-page/notice/notice-columns.util.tsx
+++ b/apps/admin/src/features/home-page/notice/notice-columns.util.tsx
@@ -1,0 +1,111 @@
+import { Button, Checkbox } from '@dessert/ui'
+
+import type { Notice } from '@/entity/home-page/notice'
+
+import type { ColumnDef } from '@tanstack/react-table'
+
+const HEADER_CLASS = 'border-b-[0.8px] border-b-gray-400'
+const CELL_CLASS = 'border-r border-gray-200 px-10 text-center'
+
+interface NoticeColumnsArgs {
+  allSelected: boolean
+  selectedIds: number[]
+  onToggleAll: (checked: boolean | 'indeterminate') => void
+  onToggleRow: (id: number, checked: boolean | 'indeterminate') => void
+  onEdit: (id: number) => void
+  onSelectNotice: (id: number) => void
+  isTableActionDisabled?: boolean
+}
+
+export const getNoticeColumns = ({
+  allSelected,
+  selectedIds,
+  onToggleAll,
+  onToggleRow,
+  onEdit,
+  onSelectNotice,
+  isTableActionDisabled = false,
+}: NoticeColumnsArgs): ColumnDef<Notice>[] => [
+  {
+    id: 'select',
+    header: () => (
+      <Checkbox
+        checked={allSelected}
+        disabled={isTableActionDisabled}
+        onCheckedChange={onToggleAll}
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={selectedIds.includes(row.original.id)}
+        disabled={isTableActionDisabled}
+        onCheckedChange={(checked) => onToggleRow(row.original.id, checked)}
+      />
+    ),
+    size: 40,
+  },
+  {
+    accessorKey: 'title',
+    header: '공지사항명',
+    cell: ({ row }) => (
+      <button
+        type="button"
+        className="block w-full truncate typo-body-14-r text-gray-900"
+        onClick={() => onSelectNotice(row.original.id)}
+      >
+        {row.original.title}
+      </button>
+    ),
+    size: 410,
+    meta: {
+      headerClassName: HEADER_CLASS,
+      className: CELL_CLASS,
+    },
+  },
+  {
+    accessorKey: 'createdAt',
+    header: '등록일자',
+    cell: ({ row }) => (
+      <span className="block truncate typo-body-14-r text-gray-900">
+        {row.original.createdAt}
+      </span>
+    ),
+    size: 200,
+    meta: {
+      headerClassName: HEADER_CLASS,
+      className: CELL_CLASS,
+    },
+  },
+  {
+    accessorKey: 'modifiedAt',
+    header: '수정일자',
+    cell: ({ row }) => (
+      <span className="block truncate typo-body-14-r text-gray-900">
+        {row.original.modifiedAt}
+      </span>
+    ),
+    size: 200,
+    meta: {
+      headerClassName: HEADER_CLASS,
+      className: CELL_CLASS,
+    },
+  },
+  {
+    id: 'edit',
+    header: '수정',
+    cell: ({ row }) => (
+      <Button
+        title="수정"
+        size="sm"
+        variant="primary-outlined"
+        disabled={isTableActionDisabled}
+        onClick={() => onEdit(row.original.id)}
+      />
+    ),
+    size: 95,
+    meta: {
+      headerClassName: HEADER_CLASS,
+      className: 'px-10 text-center',
+    },
+  },
+]

--- a/apps/admin/src/features/home-page/notice/notice-delete-confirm-dialog.ui.tsx
+++ b/apps/admin/src/features/home-page/notice/notice-delete-confirm-dialog.ui.tsx
@@ -1,0 +1,60 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@dessert/ui'
+
+interface NoticeDeleteConfirmDialogProps {
+  open: boolean
+  onClose: () => void
+  onConfirm: () => void
+  disabled?: boolean
+}
+
+export const NoticeDeleteConfirmDialog = ({
+  open,
+  onClose,
+  onConfirm,
+  disabled = false,
+}: NoticeDeleteConfirmDialogProps) => {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && !disabled) onClose()
+      }}
+    >
+      <DialogContent className="w-[300px] gap-0 px-24 py-20 sm:max-w-[300px]">
+        <DialogHeader className="items-center gap-0">
+          <DialogTitle className="typo-heading-18-m text-gray-800">
+            경고
+          </DialogTitle>
+        </DialogHeader>
+        <DialogDescription className="pt-12 pb-24 text-center typo-title-16-r text-gray-800">
+          정말 공지사항을 삭제하시나요?
+        </DialogDescription>
+        <DialogFooter className="grid grid-cols-2 gap-8">
+          <Button
+            title="취소"
+            type="button"
+            variant="secondary-outlined"
+            onClick={onClose}
+            disabled={disabled}
+            className="w-full"
+          />
+          <Button
+            title="삭제"
+            type="button"
+            onClick={onConfirm}
+            disabled={disabled}
+            className="w-full"
+          />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/admin/src/features/home-page/notice/notice-form.ui.tsx
+++ b/apps/admin/src/features/home-page/notice/notice-form.ui.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react'
+
+import { Button, Editor, Input, Label } from '@dessert/ui'
+
+import type { NoticeFormValues } from '@/entity/home-page/notice'
+
+const TITLE_MIN_LENGTH = 3
+const TITLE_MAX_LENGTH = 50
+const TITLE_HELPER_TEXT = `${TITLE_MIN_LENGTH}~${TITLE_MAX_LENGTH} 글자를 입력 하세요`
+
+/** 빈 에디터도 빈 문단 태그를 넘기므로 태그를 걷어내고 판단한다 */
+const isEditorEmpty = (value: string) =>
+  value.replace(/<(p|div|br)[^>]*>|<\/(p|div)>|&nbsp;|\s/g, '') === ''
+
+interface NoticeFormProps {
+  heading: string
+  submitTitle: string
+  defaultValues?: NoticeFormValues
+  onSubmit: (values: NoticeFormValues) => void
+  isSubmitting?: boolean
+}
+
+export const NoticeForm = ({
+  heading,
+  submitTitle,
+  defaultValues,
+  onSubmit,
+  isSubmitting = false,
+}: NoticeFormProps) => {
+  const [title, setTitle] = useState(defaultValues?.title ?? '')
+  const [content, setContent] = useState(defaultValues?.content ?? '')
+
+  const isTitleValid =
+    title.trim().length >= TITLE_MIN_LENGTH &&
+    title.trim().length <= TITLE_MAX_LENGTH
+  const canSubmit = isTitleValid && !isEditorEmpty(content) && !isSubmitting
+
+  /** 이미지 업로드 API 연동 전까지 로컬 미리보기 URL로 삽입한다 */
+  const handleImageUpload = async (file: File) => URL.createObjectURL(file)
+
+  return (
+    <form
+      className="flex flex-col gap-20 rounded-20 border border-gray-200 bg-white px-40 py-32"
+      onSubmit={(event) => {
+        event.preventDefault()
+        if (!canSubmit) return
+
+        onSubmit({ title: title.trim(), content })
+      }}
+    >
+      <h2 className="typo-heading-20-sb text-gray-900">{heading}</h2>
+
+      <Input
+        label="공지사항명"
+        required
+        placeholder="제목을 입력하세요."
+        helperText={TITLE_HELPER_TEXT}
+        value={title}
+        maxLength={TITLE_MAX_LENGTH}
+        onChange={(event) => setTitle(event.target.value)}
+      />
+
+      <div className="flex flex-col gap-8">
+        <Label label="내용" required className="sr-only" />
+        <Editor
+          value={content}
+          onChange={setContent}
+          image
+          onImageUpload={handleImageUpload}
+          placeholder="내용을 입력하세요. (권장크기 : 가로 860px)"
+          height={480}
+        />
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          type="submit"
+          title={submitTitle}
+          size="lg"
+          disabled={!canSubmit}
+        />
+      </div>
+    </form>
+  )
+}

--- a/apps/admin/src/features/home-page/notice/notice-table.ui.tsx
+++ b/apps/admin/src/features/home-page/notice/notice-table.ui.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { Table, toast } from '@dessert/ui'
+import { useNavigate } from 'react-router-dom'
+
+import { Notice, noticeMockData } from '@/entity/home-page/notice'
+import { CLIENT_NOTICE_URL, ROUTES } from '@/shared/constant'
+
+import { NoticeActionGroup } from './notice-action-group.ui'
+import { getNoticeColumns } from './notice-columns.util'
+import { NoticeDeleteConfirmDialog } from './notice-delete-confirm-dialog.ui'
+
+export const NoticeTable = () => {
+  const navigate = useNavigate()
+  const [currentPage, setCurrentPage] = useState(1)
+  const [selectedIds, setSelectedIds] = useState<number[]>([])
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+
+  // TODO(#286 후속): 목록 조회 API 연동 시 실데이터로 교체
+  const tableData: Notice[] = noticeMockData
+  const totalPages = 1
+  const allSelected =
+    tableData.length > 0 && selectedIds.length === tableData.length
+
+  useEffect(() => {
+    setSelectedIds([])
+    setIsDeleteDialogOpen(false)
+  }, [currentPage])
+
+  const handleToggleAll = useCallback(
+    (checked: boolean | 'indeterminate') => {
+      setSelectedIds(checked === true ? tableData.map((row) => row.id) : [])
+    },
+    [tableData],
+  )
+
+  const handleToggleRow = useCallback(
+    (id: number, checked: boolean | 'indeterminate') => {
+      setSelectedIds((prev) =>
+        checked === true
+          ? prev.includes(id)
+            ? prev
+            : [...prev, id]
+          : prev.filter((selectedId) => selectedId !== id),
+      )
+    },
+    [],
+  )
+
+  const handleCreate = () => {
+    navigate(ROUTES.HOMEPAGE.NOTICE_CREATE)
+  }
+
+  const handleEdit = useCallback(
+    (id: number) => {
+      navigate(ROUTES.HOMEPAGE.noticeEdit(id))
+    },
+    [navigate],
+  )
+
+  /** 공지사항명 클릭 시 클라이언트 공지사항 화면을 새 탭으로 연다 */
+  const handleSelectNotice = useCallback((id: number) => {
+    window.open(CLIENT_NOTICE_URL(id), '_blank', 'noopener,noreferrer')
+  }, [])
+
+  const handleDelete = () => {
+    if (selectedIds.length === 0) {
+      toast.info('선택된 공지사항이 없습니다.')
+      return
+    }
+
+    setIsDeleteDialogOpen(true)
+  }
+
+  const handleConfirmDelete = () => {
+    // TODO(#286 후속): 다중 삭제 API 연동
+    setSelectedIds([])
+    setIsDeleteDialogOpen(false)
+  }
+
+  const columns = useMemo(
+    () =>
+      getNoticeColumns({
+        allSelected,
+        selectedIds,
+        onToggleAll: handleToggleAll,
+        onToggleRow: handleToggleRow,
+        onEdit: handleEdit,
+        onSelectNotice: handleSelectNotice,
+      }),
+    [
+      allSelected,
+      handleEdit,
+      handleSelectNotice,
+      handleToggleAll,
+      handleToggleRow,
+      selectedIds,
+    ],
+  )
+
+  return (
+    <>
+      <Table
+        data={tableData}
+        columns={columns}
+        topArea={
+          <NoticeActionGroup
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+            onCreate={handleCreate}
+            onDelete={handleDelete}
+            isDeleteDisabled={selectedIds.length === 0}
+          />
+        }
+      />
+      <NoticeDeleteConfirmDialog
+        open={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        onConfirm={handleConfirmDelete}
+      />
+    </>
+  )
+}

--- a/apps/admin/src/pages/home-page/notice/index.ts
+++ b/apps/admin/src/pages/home-page/notice/index.ts
@@ -1,1 +1,3 @@
+export { NoticeCreatePage } from './notice-create-page'
+export { NoticeEditPage } from './notice-edit-page'
 export { NoticePage } from './notice-page'

--- a/apps/admin/src/pages/home-page/notice/notice-create-page.tsx
+++ b/apps/admin/src/pages/home-page/notice/notice-create-page.tsx
@@ -1,0 +1,19 @@
+import { useNavigate } from 'react-router-dom'
+
+import { NoticeForm } from '@/features/home-page/notice'
+import { ROUTES } from '@/shared/constant'
+
+export function NoticeCreatePage() {
+  const navigate = useNavigate()
+
+  return (
+    <NoticeForm
+      heading="공지사항 등록"
+      submitTitle="등록"
+      onSubmit={() => {
+        // TODO(#286 후속): 공지사항 등록 API 연동
+        navigate(ROUTES.HOMEPAGE.NOTICE)
+      }}
+    />
+  )
+}

--- a/apps/admin/src/pages/home-page/notice/notice-edit-page.tsx
+++ b/apps/admin/src/pages/home-page/notice/notice-edit-page.tsx
@@ -1,0 +1,25 @@
+import { useNavigate, useParams } from 'react-router-dom'
+
+import { noticeMockData } from '@/entity/home-page/notice'
+import { NoticeForm } from '@/features/home-page/notice'
+import { ROUTES } from '@/shared/constant'
+
+export function NoticeEditPage() {
+  const navigate = useNavigate()
+  const { noticeId } = useParams()
+
+  // TODO(#286 후속): 단건 조회 API 연동 시 실데이터로 교체
+  const notice = noticeMockData.find((item) => String(item.id) === noticeId)
+
+  return (
+    <NoticeForm
+      heading="공지사항 수정"
+      submitTitle="등록"
+      defaultValues={{ title: notice?.title ?? '', content: '' }}
+      onSubmit={() => {
+        // TODO(#286 후속): 공지사항 수정 API 연동
+        navigate(ROUTES.HOMEPAGE.NOTICE)
+      }}
+    />
+  )
+}

--- a/apps/admin/src/pages/home-page/notice/notice-page.tsx
+++ b/apps/admin/src/pages/home-page/notice/notice-page.tsx
@@ -1,3 +1,9 @@
+import { NoticeTable } from '@/features/home-page/notice'
+
 export function NoticePage() {
-  return <div>NoticePage</div>
+  return (
+    <section className="border-gray-300 bg-white">
+      <NoticeTable />
+    </section>
+  )
 }

--- a/apps/admin/src/shared/constant/client-url.ts
+++ b/apps/admin/src/shared/constant/client-url.ts
@@ -1,0 +1,3 @@
+/** 클라이언트(사용자) 서비스의 공지사항 상세 화면 */
+export const CLIENT_NOTICE_URL = (noticeId: number | string) =>
+  `https://www.bbanggree.com/mypage/notifications/${noticeId}`

--- a/apps/admin/src/shared/constant/index.ts
+++ b/apps/admin/src/shared/constant/index.ts
@@ -1,2 +1,3 @@
+export { CLIENT_NOTICE_URL } from './client-url'
 export { ROUTES } from './routes'
 export { TOKEN_COOKIE_KEYS } from './token'

--- a/apps/admin/src/shared/constant/routes.ts
+++ b/apps/admin/src/shared/constant/routes.ts
@@ -11,6 +11,10 @@ export const ROUTES = {
   },
   HOMEPAGE: {
     NOTICE: '/homepage/notice',
+    NOTICE_CREATE: '/homepage/notice/register',
+    NOTICE_EDIT: '/homepage/notice/:noticeId/edit',
+    noticeEdit: (noticeId: number | string) =>
+      `/homepage/notice/${noticeId}/edit`,
   },
   LOGIN: '/login',
 } as const

--- a/apps/admin/src/shared/libs/test/msw/handlers/auth.ts
+++ b/apps/admin/src/shared/libs/test/msw/handlers/auth.ts
@@ -3,14 +3,24 @@ import { HttpResponse, http } from 'msw'
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'
 
 export const authHandlers = [
-  http.post(`${BASE_URL}/api/v1/admins/login`, () => {
+  http.post(`${BASE_URL}/api/v1/admin/login`, () => {
     return HttpResponse.json({
-      accessToken: 'mock-access-token',
-      refreshToken: 'mock-refresh-token',
+      success: true,
+      code: 200,
+      message: 'OK',
+      fieldErrors: [],
+      result: {
+        accessToken: 'mock-access-token',
+        refreshToken: 'mock-refresh-token',
+      },
     })
   }),
 
-  http.post(`${BASE_URL}/api/v1/admins/logout`, () => {
-    return new HttpResponse(null, { status: 204 })
+  http.post(`${BASE_URL}/api/v1/admin/logout`, () => {
+    return HttpResponse.json({
+      success: true,
+      code: 200,
+      message: 'OK',
+    })
   }),
 ]

--- a/apps/admin/src/shared/utils/axios.ts
+++ b/apps/admin/src/shared/utils/axios.ts
@@ -48,9 +48,9 @@ export const setupAuthResponseInterceptor = (
           error.config?.unauthorizedPolicy ?? 'redirect'
 
         // 로그인 요청의 401은 무시 (onError에서 처리)
+        // 세션만 정리하면 라우트 가드가 로그인 화면으로 이동시킨다
         if (!isLoginRequest && unauthorizedPolicy === 'redirect') {
           onUnauthorized()
-          window.location.href = '/login'
         }
       }
       return Promise.reject(error)

--- a/apps/admin/src/widgets/lnb/lnb.tsx
+++ b/apps/admin/src/widgets/lnb/lnb.tsx
@@ -29,7 +29,7 @@ const MENU_LIST = [
   },
   {
     group: '홈페이지 관리',
-    items: [{ title: '홈페이지 관리', href: ROUTES.HOMEPAGE.NOTICE }],
+    items: [{ title: '공지사항 관리', href: ROUTES.HOMEPAGE.NOTICE }],
   },
 ]
 

--- a/packages/ui/src/table/table.tsx
+++ b/packages/ui/src/table/table.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react'
+
 import {
   type Cell,
   ColumnDef,
@@ -85,9 +87,8 @@ function Table<T>({
           </thead>
           <tbody>
             {getRowModel().rows.map((row) => (
-              <>
+              <Fragment key={row.id}>
                 <tr
-                  key={row.id}
                   className={cn(
                     'border-b border-gray-300 last:border-b-0',
                     getRowClassName?.(row.original),
@@ -129,7 +130,7 @@ function Table<T>({
                   })}
                 </tr>
                 {renderSubRow?.(row.original)}
-              </>
+              </Fragment>
             ))}
           </tbody>
         </table>


### PR DESCRIPTION
## 이슈 번호
Closes #288

## 작업 내용 및 테스트 방법
### 작업 내용
홈페이지 관리의 공지사항 화면이 자리표시자만 있는 상태였습니다. 디자인에 맞춰 목록, 등록, 수정 세 화면을 만들었습니다. API 연동은 별도 이슈로 진행하며, 이번 변경은 화면까지입니다.

- 목록 화면에 표, 체크박스 다중 선택, 등록·삭제 버튼, 페이지네이션을 붙였습니다. 삭제는 확인 다이얼로그를 거칩니다.
- 공지사항명을 누르면 사용자 서비스의 해당 공지사항 화면이 새 탭으로 열립니다.
- 등록과 수정 화면을 같은 폼으로 구성하고 제목과 버튼 문구만 다르게 했습니다.
- 본문 편집기는 디자이너 주석에 따라 셀러 상세페이지 등록이 쓰는 공용 편집기를 그대로 사용했습니다.
- 공지사항명에 3~50자 검증과 안내 문구를 넣었습니다.
- 편집기가 비어 있는데도 입력된 것으로 판단해 등록 버튼이 활성화되던 문제를 함께 잡았습니다. 빈 편집기가 빈 문단 태그를 값으로 넘기는 탓이었습니다.
- 좌측 메뉴에서 그룹명과 항목명이 모두 홈페이지 관리로 같아 중복으로 보이던 것을 공지사항 관리로 정리했습니다.
- 공용 표 컴포넌트가 행을 그릴 때 반복 요소에 키를 넘기지 않아 어드민의 모든 표에서 콘솔 경고가 나던 문제를 고쳤습니다.

목록 데이터는 아직 임시 데이터이며, 등록·수정·삭제 동작 지점에는 연동 위치를 주석으로 남겨두었습니다.

### 테스트 방법
1. 목록 확인: 좌측 메뉴에서 공지사항 관리 진입, 표와 등록·삭제 버튼, 페이지네이션이 디자인대로 노출되는지 확인
2. 다중 선택 삭제: 아무것도 선택하지 않고 삭제를 누르면 안내가 뜨고, 항목을 선택하면 확인 다이얼로그가 열리는지 확인
3. 등록 화면: 등록 버튼으로 이동해 제목 3자 미만이거나 본문이 비면 등록 버튼이 비활성인지, 둘 다 채우면 활성화되는지 확인
4. 수정 화면: 목록의 수정 버튼으로 이동해 기존 제목이 채워져 있는지 확인
5. 클라이언트 이동: 공지사항명을 클릭하면 사용자 서비스 공지사항 화면이 새 탭으로 열리는지 확인
6. 표 경고: 공지사항 목록, 스토어 등록, 전체 상품 관리 화면에서 콘솔에 키 관련 경고가 없는지 확인

## To reviewers
본문 편집기 툴바 구성이 디자인과 다릅니다. 디자인은 사진·링크 라벨 버튼과 서식·글자 크기·정렬 드롭다운 구성인데, 공용 편집기는 기본 툴바입니다. 디자이너가 해당 컴포넌트를 활용하라고 명시해 그대로 사용했습니다. 툴바까지 맞추려면 공용 컴포넌트를 손봐야 하고 셀러 상세페이지에도 영향이 가서 별도 논의가 필요해 보입니다.

좌측 메뉴 아코디언이 기본 접힘 상태입니다. 디자인은 모든 그룹이 펼쳐진 모습인데 기존 동작이라 이번에는 건드리지 않았습니다.

공용 표 컴포넌트 수정이 포함되어 셀러에도 영향이 갑니다. 행 병합과 하위 행을 함께 쓰는 전체 상품 관리 화면으로 렌더링을 확인했습니다.